### PR TITLE
Custom redirect for 404s

### DIFF
--- a/plugins/humanities-commons/humanities-commons.php
+++ b/plugins/humanities-commons/humanities-commons.php
@@ -2165,8 +2165,6 @@ class Humanities_Commons {
 	
 	/**
      * Redirects 404s to url defined by KC_404.
-     *
-     * @param WP $wp The WordPress object.
      */
     public function redirect_404()
     {

--- a/plugins/humanities-commons/humanities-commons.php
+++ b/plugins/humanities-commons/humanities-commons.php
@@ -2176,7 +2176,7 @@ class Humanities_Commons {
         if (!defined("KC_404")) {
             return;
         }
-        wp_redirect(getenv("KC_404"), 301);
+        wp_redirect(KC_404, 301);
         exit();
     }
 }

--- a/plugins/humanities-commons/humanities-commons.php
+++ b/plugins/humanities-commons/humanities-commons.php
@@ -159,6 +159,7 @@ class Humanities_Commons {
 
 		// Add filter to suppress activity for test users
 		add_filter('bp_activity_before_save', array($this, 'suppress_test_user_activity'), 10, 1);
+		add_action("template_redirect", [$this, "redirect_404"], 9, 0);
 	}
 
 	public function allow_external_hcommons( $external, $host, $url ) {
@@ -2161,6 +2162,23 @@ class Humanities_Commons {
 		wp_cache_set( 'test_user_ids', $test_user_ids, 'hcommons_settings', 24 * HOUR_IN_SECONDS );
 		return $test_user_ids;
 	}
+	
+	/**
+     * Redirects 404s to url defined by KC_404.
+     *
+     * @param WP $wp The WordPress object.
+     */
+    public function redirect_404()
+    {
+        if (!is_404()) {
+            return;
+        }
+        if (!defined("KC_404")) {
+            return;
+        }
+        wp_redirect(getenv("KC_404"), 301);
+        exit();
+    }
 }
 
 $humanities_commons = new Humanities_Commons;

--- a/site/config/application.php
+++ b/site/config/application.php
@@ -200,9 +200,9 @@ Config::define('PATH_CURRENT_SITE', '/');
 Config::define('PRIMARY_NETWORK_ID', 1);
 
 /**
- * Redirect nonexistent blogs
+ * Redirect 404s to url defined by KC_404.
  */
-Config::define('NOBLOGREDIRECT', getenv('WP_HOME'));
+Config::define("KC_404", getenv("KC_404"));
 
 /**
  * Akismet


### PR DESCRIPTION
- Remove NOBLOGREDIRECT constant that causes 404 errors to redirect to homepage.
- Add hook to redirect 404 errors to URL defined by KC_404 environment variable. This operates at a higher priority than maybe_redirect_404.