### PR TITLE
Disable group cover image uploads

### DIFF
--- a/plugins/hc-custom/hc-custom.php
+++ b/plugins/hc-custom/hc-custom.php
@@ -18,6 +18,7 @@
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-core.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-blogs.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-groups.php';
+require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-groups-cover-image.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-members.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-activity.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-xprofile.php';

--- a/plugins/hc-custom/includes/buddypress/bp-groups-cover-image.php
+++ b/plugins/hc-custom/includes/buddypress/bp-groups-cover-image.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Disables BuddyPress group cover image uploads.
+ *
+ * The active theme no longer supports group cover images, so the upload UI
+ * must be removed from the group creation wizard and the Manage > Cover
+ * Image settings screen. BuddyPress gates both behind
+ * bp_group_use_cover_image_header(), which returns false when the
+ * bp_disable_group_cover_image_uploads filter returns true.
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Forces group cover image uploads to be treated as disabled.
+ *
+ * @param bool $disabled Whether cover image uploads are disabled by option.
+ *
+ * @return bool Always true: cover image uploads are unsupported.
+ */
+function hcommons_disable_group_cover_image_uploads( $disabled = false ) {
+	return true;
+}
+add_filter( 'bp_disable_group_cover_image_uploads', 'hcommons_disable_group_cover_image_uploads' );

--- a/tests/unit/GroupCoverImageTest.php
+++ b/tests/unit/GroupCoverImageTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/group-cover-image-loader.php';
+
+/**
+ * Group cover image uploads must be disabled site-wide: BuddyPress removes
+ * both the create-a-group "cover image" step and the Manage > Cover Image
+ * settings screen when the bp_disable_group_cover_image_uploads filter
+ * resolves to true.
+ */
+class GroupCoverImageTest extends TestCase {
+
+	/**
+	 * The filter callback reports uploads as disabled even when the
+	 * stored BuddyPress option would allow them.
+	 */
+	public function testCallbackDisablesUploadsWhenOptionAllowsThem(): void {
+		$this->assertTrue( hcommons_disable_group_cover_image_uploads( false ) );
+	}
+
+	/**
+	 * The filter callback keeps uploads disabled when the option already
+	 * disables them.
+	 */
+	public function testCallbackKeepsUploadsDisabledWhenOptionDisablesThem(): void {
+		$this->assertTrue( hcommons_disable_group_cover_image_uploads( true ) );
+	}
+
+	/**
+	 * The callback returns a strict boolean, matching what BuddyPress
+	 * expects from the filter.
+	 */
+	public function testCallbackReturnsBoolean(): void {
+		$this->assertIsBool( hcommons_disable_group_cover_image_uploads() );
+	}
+
+	/**
+	 * Loading the plugin file wires the disable filter: resolving the
+	 * bp_disable_group_cover_image_uploads hook over an enabled (false)
+	 * option value must yield true, which is what removes the cover image
+	 * step from group creation and the Manage settings screen.
+	 */
+	public function testLoadingFileRegistersDisableFilter(): void {
+		$this->assertTrue(
+			_test_apply_captured_filters( 'bp_disable_group_cover_image_uploads', false )
+		);
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -252,7 +252,9 @@ if ( ! class_exists( 'WP_REST_Request' ) ) {
 
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
-		// no-op for unit tests
+		// Recorded so tests can resolve captured hooks; otherwise a no-op.
+		$GLOBALS['_captured_filters'][ $hook ][] = $callback;
+		return true;
 	}
 }
 

--- a/tests/unit/group-cover-image-loader.php
+++ b/tests/unit/group-cover-image-loader.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Loads the hc-custom group cover image disabling code for unit testing,
+ * with a capturing add_filter stub so hook registration can be exercised
+ * behaviorally without loading WordPress.
+ */
+
+if ( ! isset( $GLOBALS['_captured_filters'] ) ) {
+	$GLOBALS['_captured_filters'] = [];
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['_captured_filters'][ $hook ][] = $callback;
+		return true;
+	}
+}
+
+if ( ! function_exists( '_test_apply_captured_filters' ) ) {
+	/**
+	 * Minimal apply_filters equivalent: folds a value through every callback
+	 * captured for a hook, mimicking how WordPress would resolve the filter.
+	 */
+	function _test_apply_captured_filters( $hook, $value ) {
+		foreach ( $GLOBALS['_captured_filters'][ $hook ] ?? [] as $callback ) {
+			$value = call_user_func( $callback, $value );
+		}
+		return $value;
+	}
+}
+
+require_once __DIR__ . '/../../plugins/hc-custom/includes/buddypress/bp-groups-cover-image.php';


### PR DESCRIPTION
## Summary

Removes the group cover image upload UI from both the create-a-group wizard and the group Manage settings, per #106. The active theme no longer supports group cover images, but BuddyPress was still offering the upload step and settings screen.

## Approach

BuddyPress gates all group cover image UI behind `bp_group_use_cover_image_header()`, which returns false whenever the `bp_disable_group_cover_image_uploads` filter resolves to true. When that happens, `BP_Groups_Component` unsets the `group-cover-image` creation step and the `group-cover-image` manage screen, and the cover image REST attachment endpoint rejects uploads.

This PR adds `plugins/hc-custom/includes/buddypress/bp-groups-cover-image.php`, which hooks that filter and forces it to true, and wires the file into the hc-custom loader. Group avatar uploads are untouched.

## Testing

Unit tests in `tests/unit/GroupCoverImageTest.php` (with a loader that stubs `add_filter` and loads the real plugin file) verify the callback reports uploads as disabled regardless of the stored option and that loading the file registers the filter so the hook resolves to true. Full unit suite passes: 30 tests, 53 assertions.

Fixes #106