### PR TITLE
Stop group event date/time pickers scrolling the page to the top

### DIFF
--- a/plugins/bp-event-organiser/assets/js/datepicker-scroll-fix.js
+++ b/plugins/bp-event-organiser/assets/js/datepicker-scroll-fix.js
@@ -1,0 +1,46 @@
+/**
+ * Stop the event date/time pickers scrolling the page to the top.
+ *
+ * The jQuery UI datepicker and the Event Organiser timepicker render their
+ * day/hour/minute cells as `<a href="#">`. Their click handlers are supposed
+ * to `return false`, but if anything in the selection callbacks throws (or a
+ * handler is missing), the browser follows the `#` href and jumps to the top
+ * of the page.
+ *
+ * This capture-phase listener cancels that default navigation for hash-only
+ * anchors inside the picker widgets. It does not stop propagation, so the
+ * widgets' own click handling continues to work exactly as before.
+ */
+( function() {
+	'use strict';
+
+	if ( ! document.addEventListener || ! Element.prototype.closest ) {
+		return;
+	}
+
+	var PICKER_CONTAINERS = '#ui-datepicker-div, #ui-timepicker-div, .ui-datepicker, .ui-timepicker';
+
+	document.addEventListener( 'click', function( event ) {
+		var target = event.target;
+
+		if ( ! target || ! target.closest ) {
+			return;
+		}
+
+		var anchor = target.closest( 'a' );
+
+		if ( ! anchor ) {
+			return;
+		}
+
+		var href = anchor.getAttribute( 'href' );
+
+		if ( '#' !== href && '' !== href ) {
+			return;
+		}
+
+		if ( anchor.closest( PICKER_CONTAINERS ) ) {
+			event.preventDefault();
+		}
+	}, true );
+} )();

--- a/plugins/bp-event-organiser/bp-event-organiser.php
+++ b/plugins/bp-event-organiser/bp-event-organiser.php
@@ -49,6 +49,7 @@ if ( ! defined( 'BPEO_EVENTS_NEW_SLUG' ) ) {
  */
 function bpeo_include() {
 	require( BPEO_PATH . 'includes/functions.php' );
+	require( BPEO_PATH . 'includes/datepicker-scroll-fix.php' );
 	require( BPEO_PATH . 'includes/component.php' );
 	require( BPEO_PATH . 'includes/user.php' );
 

--- a/plugins/bp-event-organiser/includes/datepicker-scroll-fix.php
+++ b/plugins/bp-event-organiser/includes/datepicker-scroll-fix.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Enqueue a shim that stops the event date/time pickers scrolling the page
+ * to the top when a date or time is selected.
+ *
+ * @package bp-event-organiser
+ */
+
+/**
+ * Enqueue the date/time picker scroll fix on event edit screens.
+ *
+ * @return string|false The enqueued script handle, or false when not on an
+ *                      event edit screen.
+ */
+function bpeo_enqueue_datepicker_scroll_fix() {
+	// Only load alongside Event Organiser's event edit form assets. These are
+	// enqueued (at default priority) by the frontend admin screens used for
+	// creating and editing group and member events.
+	if ( ! wp_script_is( 'eo_event' ) && ! wp_script_is( 'eo-edit-event-controller' ) ) {
+		return false;
+	}
+
+	wp_enqueue_script(
+		'bpeo-datepicker-scroll-fix',
+		BUDDYPRESS_EVENT_ORGANISER_URL . 'assets/js/datepicker-scroll-fix.js',
+		array(),
+		BUDDYPRESS_EVENT_ORGANISER_VERSION,
+		true
+	);
+
+	return 'bpeo-datepicker-scroll-fix';
+}
+add_action( 'wp_enqueue_scripts', 'bpeo_enqueue_datepicker_scroll_fix', 20 );

--- a/tests/unit/DatepickerScrollFixTest.php
+++ b/tests/unit/DatepickerScrollFixTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'BUDDYPRESS_EVENT_ORGANISER_URL' ) ) {
+	define( 'BUDDYPRESS_EVENT_ORGANISER_URL', 'https://example.org/app/plugins/bp-event-organiser/' );
+}
+if ( ! defined( 'BUDDYPRESS_EVENT_ORGANISER_VERSION' ) ) {
+	define( 'BUDDYPRESS_EVENT_ORGANISER_VERSION', '0.2' );
+}
+
+require_once __DIR__ . '/../../plugins/bp-event-organiser/includes/datepicker-scroll-fix.php';
+
+class DatepickerScrollFixTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['_enqueued_scripts'] = [];
+		unset( $GLOBALS['_mock_wp_script_is_callback'] );
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['_enqueued_scripts'] = [];
+		unset( $GLOBALS['_mock_wp_script_is_callback'] );
+	}
+
+	/**
+	 * On a screen where Event Organiser's event edit script is queued,
+	 * the scroll-fix script is enqueued and its handle returned.
+	 */
+	public function testEnqueuesFixWhenEventEditScriptQueued(): void {
+		$GLOBALS['_mock_wp_script_is_callback'] = function ( $handle, $status ) {
+			return 'eo_event' === $handle;
+		};
+
+		$result = bpeo_enqueue_datepicker_scroll_fix();
+
+		$this->assertSame( 'bpeo-datepicker-scroll-fix', $result );
+		$this->assertArrayHasKey( 'bpeo-datepicker-scroll-fix', $GLOBALS['_enqueued_scripts'] );
+	}
+
+	/**
+	 * The edit-event controller script implies the event edit form too.
+	 */
+	public function testEnqueuesFixWhenEditControllerQueued(): void {
+		$GLOBALS['_mock_wp_script_is_callback'] = function ( $handle, $status ) {
+			return 'eo-edit-event-controller' === $handle;
+		};
+
+		$result = bpeo_enqueue_datepicker_scroll_fix();
+
+		$this->assertSame( 'bpeo-datepicker-scroll-fix', $result );
+		$this->assertArrayHasKey( 'bpeo-datepicker-scroll-fix', $GLOBALS['_enqueued_scripts'] );
+	}
+
+	/**
+	 * On any other page the fix is not enqueued and false is returned.
+	 */
+	public function testDoesNotEnqueueOnOtherPages(): void {
+		$result = bpeo_enqueue_datepicker_scroll_fix();
+
+		$this->assertFalse( $result );
+		$this->assertSame( [], $GLOBALS['_enqueued_scripts'] );
+	}
+
+	/**
+	 * The enqueued src points at a real asset shipped by the plugin,
+	 * loaded in the footer with the plugin version.
+	 */
+	public function testEnqueuedScriptPointsToRealAsset(): void {
+		$GLOBALS['_mock_wp_script_is_callback'] = function () {
+			return true;
+		};
+
+		bpeo_enqueue_datepicker_scroll_fix();
+
+		$script = $GLOBALS['_enqueued_scripts']['bpeo-datepicker-scroll-fix'];
+
+		$this->assertStringStartsWith( BUDDYPRESS_EVENT_ORGANISER_URL, $script['src'] );
+
+		$relative = substr( $script['src'], strlen( BUDDYPRESS_EVENT_ORGANISER_URL ) );
+		$asset    = __DIR__ . '/../../plugins/bp-event-organiser/' . $relative;
+
+		$this->assertFileExists( $asset );
+		$this->assertGreaterThan( 0, filesize( $asset ) );
+		$this->assertTrue( $script['in_footer'] );
+		$this->assertSame( BUDDYPRESS_EVENT_ORGANISER_VERSION, $script['ver'] );
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -216,6 +216,21 @@ if ( ! function_exists( 'set_transient' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_script_is' ) ) {
+	function wp_script_is( $handle, $status = 'enqueued' ) {
+		if ( isset( $GLOBALS['_mock_wp_script_is_callback'] ) ) {
+			return (bool) call_user_func( $GLOBALS['_mock_wp_script_is_callback'], $handle, $status );
+		}
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_script' ) ) {
+	function wp_enqueue_script( $handle, $src = '', $deps = [], $ver = false, $in_footer = false ) {
+		$GLOBALS['_enqueued_scripts'][ $handle ] = compact( 'handle', 'src', 'deps', 'ver', 'in_footer' );
+	}
+}
+
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		public $code;


### PR DESCRIPTION
## Summary

Selecting a date or a begin/end time on the group event form (Group > Events > New Event) made the page jump back to the very top, forcing users to scroll down to the form again (#99).

## Root cause

The event form uses the jQuery UI datepicker plus Event Organiser's timepicker addon. Both widgets render their day/hour/minute cells as `<a href="#">` and rely on their click handlers returning `false` to suppress the default anchor navigation. Event Organiser's selection callbacks are fragile on the frontend admin screen (e.g. `event.js`'s `onSelect` calls `startDate.getTime() != endDate.getTime()` on values that can be `null`, and cross-references the recurrence picker); when any of them throws, `return false` is never reached, the browser follows the `#` href, and the page scrolls to the top. The same failure mode applies to all four fields (both dates and both times).

Event Organiser is third-party code, so the fix lands in `plugins/bp-event-organiser` instead.

## Fix

- New `assets/js/datepicker-scroll-fix.js`: a capture-phase click listener that calls `preventDefault()` on hash-only anchors inside the datepicker/timepicker containers. It does not stop propagation, so the widgets' own click handling is untouched; it only cancels the navigation the widgets already intend to suppress.
- New `includes/datepicker-scroll-fix.php`: enqueues the shim on `wp_enqueue_scripts` (priority 20) only when Event Organiser's event edit scripts (`eo_event` / `eo-edit-event-controller`) are queued, i.e. only on the event create/edit screens.

## Tests

Unit tests in `tests/unit/DatepickerScrollFixTest.php` (with new `wp_script_is`/`wp_enqueue_script` stubs in the shared bootstrap) cover: enqueueing on event edit contexts, staying inert elsewhere, and the enqueued handle pointing at a real footer-loaded asset. Full suite: 30 tests, 60 assertions, all passing.

Fixes #99