### PR TITLE
Fix crowded time picker grid on group event forms

### DIFF
--- a/plugins/bp-event-organiser/assets/css/bpeo-timepicker.css
+++ b/plugins/bp-event-organiser/assets/css/bpeo-timepicker.css
@@ -1,0 +1,47 @@
+/**
+ * Declutter the Event Organiser jQuery UI timepicker grid.
+ *
+ * The active theme applies a global `*, *::before, *::after { box-sizing:
+ * border-box }` reset. The timepicker stylesheet bundled with Event Organiser
+ * sizes its hour/minute cells for the default content-box model (1.2em width
+ * plus horizontal padding), so under border-box the padding swallows the
+ * width and two-digit values collide into an unreadable grid.
+ *
+ * All selectors below are scoped to the timepicker containers
+ * (#ui-timepicker-div for the popup, .ui-timepicker-inline for the inline
+ * variant), so the datepicker and other jQuery UI widgets are unaffected.
+ * The ID/extra-class scoping also outweighs the bundled rules regardless of
+ * stylesheet order.
+ */
+
+#ui-timepicker-div .ui-timepicker-table td,
+#ui-timepicker-div .ui-timepicker-table th.periods,
+.ui-timepicker-inline .ui-timepicker-table td,
+.ui-timepicker-inline .ui-timepicker-table th.periods {
+	width: auto;
+	padding: 0.15em;
+}
+
+#ui-timepicker-div .ui-timepicker-table td a,
+#ui-timepicker-div .ui-timepicker-table td span,
+.ui-timepicker-inline .ui-timepicker-table td a,
+.ui-timepicker-inline .ui-timepicker-table td span {
+	box-sizing: content-box;
+	width: 1.5em;
+	padding: 0.3em 0.35em;
+	text-align: center;
+	line-height: 1.3;
+}
+
+#ui-timepicker-div .ui-timepicker-hours,
+#ui-timepicker-div .ui-timepicker-minutes,
+.ui-timepicker-inline .ui-timepicker-hours,
+.ui-timepicker-inline .ui-timepicker-minutes {
+	padding: 0.3em 0.4em;
+	vertical-align: top;
+}
+
+#ui-timepicker-div .ui-timepicker-title,
+.ui-timepicker-inline .ui-timepicker-title {
+	padding: 0.3em 0;
+}

--- a/plugins/bp-event-organiser/bp-event-organiser.php
+++ b/plugins/bp-event-organiser/bp-event-organiser.php
@@ -52,6 +52,7 @@ function bpeo_include() {
 	require( BPEO_PATH . 'includes/datepicker-scroll-fix.php' );
 	require( BPEO_PATH . 'includes/component.php' );
 	require( BPEO_PATH . 'includes/user.php' );
+	require( BPEO_PATH . 'includes/timepicker-style.php' );
 
 	if ( bp_is_active( 'activity' ) ) {
 		require( BPEO_PATH . 'includes/activity.php' );

--- a/plugins/bp-event-organiser/includes/timepicker-style.php
+++ b/plugins/bp-event-organiser/includes/timepicker-style.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Frontend override styles for the Event Organiser jQuery UI timepicker.
+ *
+ * The active theme applies a global `box-sizing: border-box` reset, which
+ * collapses the timepicker's hour/minute cells (sized for the default
+ * content-box model), leaving the grid crowded and unreadable. This loads a
+ * small stylesheet, scoped to the timepicker container, that restores
+ * comfortable cell sizing on BuddyPress event pages.
+ */
+
+/**
+ * Enqueue the timepicker override stylesheet on BPEO component pages.
+ *
+ * @return bool True if the stylesheet was enqueued, false otherwise.
+ */
+function bpeo_enqueue_timepicker_style() {
+	if ( ! bpeo_is_component() ) {
+		return false;
+	}
+
+	wp_enqueue_style(
+		'bpeo-timepicker',
+		BUDDYPRESS_EVENT_ORGANISER_URL . 'assets/css/bpeo-timepicker.css',
+		array(),
+		BUDDYPRESS_EVENT_ORGANISER_VERSION
+	);
+
+	return true;
+}
+add_action( 'wp_enqueue_scripts', 'bpeo_enqueue_timepicker_style', 20 );

--- a/tests/unit/BpeoTimepickerStyleTest.php
+++ b/tests/unit/BpeoTimepickerStyleTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../plugins/bp-event-organiser/includes/timepicker-style.php';
+
+class BpeoTimepickerStyleTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['_enqueued_styles']       = [];
+		$GLOBALS['_mock_bpeo_is_component'] = false;
+
+		if ( ! defined( 'BUDDYPRESS_EVENT_ORGANISER_URL' ) ) {
+			define( 'BUDDYPRESS_EVENT_ORGANISER_URL', 'https://example.org/wp-content/plugins/bp-event-organiser/' );
+		}
+		if ( ! defined( 'BUDDYPRESS_EVENT_ORGANISER_VERSION' ) ) {
+			define( 'BUDDYPRESS_EVENT_ORGANISER_VERSION', '0.2' );
+		}
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['_enqueued_styles'], $GLOBALS['_mock_bpeo_is_component'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * On a BuddyPress events component page the override stylesheet is enqueued.
+	 */
+	public function test_enqueues_stylesheet_on_event_component_page(): void {
+		$GLOBALS['_mock_bpeo_is_component'] = true;
+
+		$this->assertTrue( bpeo_enqueue_timepicker_style() );
+		$this->assertArrayHasKey( 'bpeo-timepicker', $GLOBALS['_enqueued_styles'] );
+	}
+
+	/**
+	 * The enqueued stylesheet is a CSS file served from the plugin's own assets.
+	 */
+	public function test_stylesheet_src_is_plugin_css_asset(): void {
+		$GLOBALS['_mock_bpeo_is_component'] = true;
+
+		bpeo_enqueue_timepicker_style();
+
+		$style = $GLOBALS['_enqueued_styles']['bpeo-timepicker'];
+		$this->assertStringStartsWith( BUDDYPRESS_EVENT_ORGANISER_URL, $style['src'] );
+		$this->assertStringEndsWith( '.css', $style['src'] );
+
+		// The referenced asset must actually exist in the plugin.
+		$relative = substr( $style['src'], strlen( BUDDYPRESS_EVENT_ORGANISER_URL ) );
+		$this->assertFileExists(
+			__DIR__ . '/../../plugins/bp-event-organiser/' . $relative
+		);
+	}
+
+	/**
+	 * Outside the events component nothing is enqueued.
+	 */
+	public function test_does_not_enqueue_outside_event_component(): void {
+		$GLOBALS['_mock_bpeo_is_component'] = false;
+
+		$this->assertFalse( bpeo_enqueue_timepicker_style() );
+		$this->assertArrayNotHasKey( 'bpeo-timepicker', $GLOBALS['_enqueued_styles'] );
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -231,6 +231,22 @@ if ( ! function_exists( 'wp_enqueue_script' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_enqueue_style' ) ) {
+	function wp_enqueue_style( $handle, $src = '', $deps = [], $ver = false, $media = 'all' ) {
+		$GLOBALS['_enqueued_styles'][ $handle ] = compact( 'handle', 'src', 'deps', 'ver', 'media' );
+	}
+}
+
+if ( ! function_exists( 'bpeo_is_component' ) ) {
+	/**
+	 * Stub of bp-event-organiser's component check. Controlled per-test via
+	 * $GLOBALS['_mock_bpeo_is_component'].
+	 */
+	function bpeo_is_component() {
+		return ! empty( $GLOBALS['_mock_bpeo_is_component'] );
+	}
+}
+
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		public $code;


### PR DESCRIPTION
## Summary

The time picker on the group event create/edit form (BuddyPress group > Events > New Event) rendered as a cramped grid with hour and minute values running into each other (#100).

## Root cause

The theme applies a global `*, *::before, *::after { box-sizing: border-box }` reset. The jQuery UI timepicker stylesheet bundled with Event Organiser sizes its hour/minute anchors as `width: 1.2em` plus `0.8em` of horizontal padding, assuming the default content-box model. Under border-box the padding swallows the declared width, leaving roughly 0.4em for the text, so two-digit values overflow their cells and collide with their neighbours.

## Fix

- New stylesheet `plugins/bp-event-organiser/assets/css/bpeo-timepicker.css` scoped to the timepicker containers only (`#ui-timepicker-div` popup and `.ui-timepicker-inline`): restores `box-sizing: content-box` for the hour/minute cells and gives them comfortable width, padding, and centred text. The ID scoping outweighs the bundled rules regardless of load order and cannot leak into the datepicker or other jQuery UI widgets.
- New `bpeo_enqueue_timepicker_style()` in `plugins/bp-event-organiser/includes/timepicker-style.php`, hooked to `wp_enqueue_scripts` and gated on `bpeo_is_component()`, so the override only loads on BuddyPress event pages.

## Tests

`tests/unit/BpeoTimepickerStyleTest.php` covers the enqueue behaviour with stubbed WP functions (enqueued on the events component, not elsewhere, and the referenced asset exists). Full suite: 29 tests, 56 assertions, all passing.

Fixes #100