### PR TITLE
Fix group navigation: docs links and missing send-invites tab

### DIFF
--- a/plugins/hc-custom/hc-custom.php
+++ b/plugins/hc-custom/hc-custom.php
@@ -42,6 +42,7 @@ require_once trailingslashit( __DIR__ ) . 'includes/buddypress-more-privacy-opti
 require_once trailingslashit( __DIR__ ) . 'includes/cbox-auth.php';
 require_once trailingslashit( __DIR__ ) . 'includes/elasticpress-buddypress.php';
 require_once trailingslashit( __DIR__ ) . 'includes/humcore.php';
+require_once trailingslashit( __DIR__ ) . 'includes/invite-anyone.php';
 require_once trailingslashit( __DIR__ ) . 'includes/mashsharer.php';
 require_once trailingslashit( __DIR__ ) . 'includes/siteorigin-panels.php';
 require_once trailingslashit( __DIR__ ) . 'includes/wp-to-twitter.php';

--- a/plugins/hc-custom/includes/buddypress-docs.php
+++ b/plugins/hc-custom/includes/buddypress-docs.php
@@ -517,6 +517,121 @@ function hcommons_restricted_comment_terms_doc_fallback( $terms, $term_query ) {
 add_action( 'terms_pre_query', 'hcommons_restricted_comment_terms_doc_fallback', 10, 2 );
 
 /**
+ * Get the URL of a group's Docs list.
+ *
+ * This addresses @link https://github.com/MESH-Research/knowledge-commons-wordpress/issues/101
+ *
+ * The upstream tabs-legacy.php template fails to echo the return value of
+ * esc_url( bp_get_group_url( ... ) ), leaving a relative href="docs" that
+ * resolves to /groups/{slug}/docs/docs and is then treated as a doc-slug
+ * lookup, which can land on another group's doc. This helper always returns
+ * an absolute URL for the requested group.
+ *
+ * @param object|int|null $group Group object or ID. Defaults to the current group.
+ * @return string The group's Docs URL, or an empty string if unavailable.
+ */
+function hc_custom_get_group_docs_url( $group = null ) {
+	if ( ! function_exists( 'bp_docs_get_group_docs_url' ) ) {
+		return '';
+	}
+
+	if ( ! $group && function_exists( 'groups_get_current_group' ) ) {
+		$group = groups_get_current_group();
+	}
+
+	if ( ! $group ) {
+		return '';
+	}
+
+	$url = bp_docs_get_group_docs_url( $group );
+
+	return $url ? $url : '';
+}
+
+/**
+ * Build a "back to the group's Docs" tab for a single doc.
+ *
+ * Single docs are viewed at the global /docs/{slug} URL, outside the group
+ * context, so the docs tabs offer no way back to the owning group's docs
+ * list. This helper resolves the doc's associated group so the tabs template
+ * can render a link back to it. Hidden groups are not revealed to
+ * non-members.
+ *
+ * @param int $doc_id ID of the doc.
+ * @return array|null Array with 'url' and 'label' keys, or null when the doc
+ *                    has no (visible) associated group.
+ */
+function hc_custom_get_doc_group_docs_tab( $doc_id ) {
+	if ( ! $doc_id || ! function_exists( 'bp_docs_get_associated_group_id' ) ) {
+		return null;
+	}
+
+	$group_id = (int) bp_docs_get_associated_group_id( $doc_id );
+
+	if ( ! $group_id ) {
+		return null;
+	}
+
+	$group = groups_get_group( array( 'group_id' => $group_id ) );
+
+	if ( empty( $group->id ) || empty( $group->name ) ) {
+		return null;
+	}
+
+	// Do not reveal hidden groups to non-members.
+	if ( isset( $group->status ) && 'hidden' === $group->status ) {
+		$can_moderate = function_exists( 'bp_current_user_can' ) && bp_current_user_can( 'bp_moderate' );
+
+		if ( ! $can_moderate && ! groups_is_user_member( bp_loggedin_user_id(), $group_id ) ) {
+			return null;
+		}
+	}
+
+	$url = hc_custom_get_group_docs_url( $group );
+
+	if ( ! $url ) {
+		return null;
+	}
+
+	return array(
+		'url'   => $url,
+		/* translators: %s: group name */
+		'label' => sprintf( __( "%s's Docs", 'hc-custom' ), $group->name ),
+	);
+}
+
+/**
+ * Replace the buddypress-docs legacy tabs template with a corrected copy.
+ *
+ * The hc-custom copy fixes the un-echoed group docs URL and adds a link back
+ * to the owning group's docs list when viewing a single doc. A template
+ * provided by the theme (anything outside buddypress-docs) is left alone.
+ *
+ * @param string $template_path Located template path.
+ * @param string $template      Requested template file name.
+ * @return string Template path to load.
+ */
+function hc_custom_bp_docs_tabs_template( $template_path, $template ) {
+	if ( 'tabs-legacy.php' !== $template ) {
+		return $template_path;
+	}
+
+	// Respect overrides located outside the buddypress-docs plugin.
+	if ( false === strpos( (string) $template_path, 'buddypress-docs' ) ) {
+		return $template_path;
+	}
+
+	$override = trailingslashit( __DIR__ ) . 'templates/docs/tabs-legacy.php';
+
+	if ( file_exists( $override ) ) {
+		return $override;
+	}
+
+	return $template_path;
+}
+add_filter( 'bp_docs_locate_template', 'hc_custom_bp_docs_tabs_template', 10, 2 );
+
+/**
  * Enqueue buddypress-docs js
  */
 function enqueue_buddypress_docs_js() {

--- a/plugins/hc-custom/includes/invite-anyone.php
+++ b/plugins/hc-custom/includes/invite-anyone.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Custom changes to the Invite Anyone plugin.
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Whether the current user may use invite-anyone in a group.
+ *
+ * Mirrors the checks in BP_Invite_Anyone::enable_nav_item(), but is safe to
+ * call once the current group has actually been resolved.
+ *
+ * @param int $group_id Group ID. Defaults to the current group.
+ * @param int $user_id  User ID. Defaults to the logged-in user.
+ * @return bool
+ */
+function hc_custom_user_can_use_invite_anyone( $group_id = 0, $user_id = 0 ) {
+	if ( ! function_exists( 'bp_groups_user_can_send_invites' ) || ! function_exists( 'invite_anyone_group_invite_access_test' ) ) {
+		return false;
+	}
+
+	if ( ! $group_id && function_exists( 'bp_get_current_group_id' ) ) {
+		$group_id = bp_get_current_group_id();
+	}
+
+	if ( ! $group_id ) {
+		return false;
+	}
+
+	if ( ! bp_groups_user_can_send_invites( $group_id, $user_id ) ) {
+		return false;
+	}
+
+	return 'anyone' === invite_anyone_group_invite_access_test( $group_id, $user_id );
+}
+
+/**
+ * Restore the invite-anyone "Send Invites" group tab on BuddyPress 12+.
+ *
+ * This addresses @link https://github.com/MESH-Research/knowledge-commons-wordpress/issues/101
+ *
+ * Invite Anyone computes its enable_nav_item() value in the constructor of
+ * BP_Invite_Anyone, which BuddyPress instantiates at bp_init:11. Since
+ * BuddyPress 12 the requested group is not resolved until bp_parse_query, so
+ * bp_get_current_group_id() is still 0 at that point, the capability check
+ * fails, and the extension registers itself with access and visibility set
+ * to 'noone' — the Send Invites tab disappears from every existing group.
+ *
+ * By bp_actions the current group is known, so constructing a fresh
+ * instance here lets the extension evaluate its own access rules correctly.
+ * We register it at priority 7, just before BuddyPress registers group
+ * extensions at priority 8; re-registering the same slug simply overwrites
+ * the earlier, broken registration.
+ *
+ * @return bool True if the extension was re-registered.
+ */
+function hc_custom_restore_invite_anyone_group_nav() {
+	if ( ! function_exists( 'bp_is_group' ) || ! bp_is_group() ) {
+		return false;
+	}
+
+	if ( ! class_exists( 'BP_Invite_Anyone' ) ) {
+		return false;
+	}
+
+	if ( ! hc_custom_user_can_use_invite_anyone() ) {
+		return false;
+	}
+
+	$extension = new BP_Invite_Anyone();
+	$extension->_register();
+
+	return true;
+}
+add_action( 'bp_actions', 'hc_custom_restore_invite_anyone_group_nav', 7 );

--- a/plugins/hc-custom/includes/templates/docs/tabs-legacy.php
+++ b/plugins/hc-custom/includes/templates/docs/tabs-legacy.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Corrected copy of the buddypress-docs legacy tabs template.
+ *
+ * Two changes from the upstream template:
+ *
+ * 1. The "[group]'s Docs" tab URL is echoed properly (upstream calls
+ *    esc_url() without echoing, producing a relative href="docs" that can
+ *    resolve to another group's doc).
+ * 2. When viewing a single doc outside the group context, a tab linking back
+ *    to the owning group's docs list is added.
+ *
+ * @package Hc_Custom
+ */
+
+?>
+<ul id="bp-docs-all-docs">
+	<li<?php if ( bp_docs_is_global_directory() ) : ?> class="current"<?php endif; ?>><a href="<?php bp_docs_archive_link(); ?>"><?php _e( 'All Docs', 'buddypress-docs' ); ?></a></li>
+
+	<?php if ( function_exists( 'bp_is_group' ) && bp_is_group() ) : ?>
+		<li<?php if ( bp_is_current_action( BP_DOCS_SLUG ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo esc_url( hc_custom_get_group_docs_url( groups_get_current_group() ) ); ?>"><?php echo esc_html( sprintf( __( "%s's Docs", 'buddypress-docs' ), bp_get_current_group_name() ) ); ?></a></li>
+	<?php else : ?>
+		<?php
+		// On a single doc, link back to the owning group's docs list.
+		$hc_custom_doc_group_tab = null;
+
+		if ( function_exists( 'bp_docs_is_existing_doc' ) && bp_docs_is_existing_doc() && function_exists( 'bp_docs_get_current_doc' ) ) {
+			$hc_custom_current_doc = bp_docs_get_current_doc();
+
+			if ( ! empty( $hc_custom_current_doc->ID ) ) {
+				$hc_custom_doc_group_tab = hc_custom_get_doc_group_docs_tab( $hc_custom_current_doc->ID );
+			}
+		}
+		?>
+		<?php if ( $hc_custom_doc_group_tab ) : ?>
+			<li><a href="<?php echo esc_url( $hc_custom_doc_group_tab['url'] ); ?>"><?php echo esc_html( $hc_custom_doc_group_tab['label'] ); ?></a></li>
+		<?php endif; ?>
+	<?php endif; ?>
+
+	<?php if ( is_user_logged_in() ) : ?>
+		<?php if ( ! function_exists( 'bp_is_group' ) || ! bp_is_group() ) : ?>
+			<li><a href="<?php bp_docs_mydocs_started_link(); ?>"><?php _e( 'Started By Me', 'buddypress-docs' ); ?></a></li>
+			<li><a href="<?php bp_docs_mydocs_edited_link(); ?>"><?php _e( 'Edited By Me', 'buddypress-docs' ); ?></a></li>
+
+			<?php if ( bp_is_active( 'groups' ) ) : ?>
+				<li<?php if ( bp_docs_is_mygroups_docs() ) : ?> class="current"<?php endif; ?>><a href="<?php bp_docs_mygroups_link(); ?>"><?php _e( 'My Groups', 'buddypress-docs' ); ?></a></li>
+			<?php endif; ?>
+		<?php endif; ?>
+	<?php endif; ?>
+
+	<?php if ( $show_create_button ) : ?>
+		<?php bp_docs_create_button(); ?>
+	<?php endif; ?>
+
+</ul>

--- a/tests/unit/GroupNavTest.php
+++ b/tests/unit/GroupNavTest.php
@@ -42,7 +42,7 @@ class GroupNavTest extends TestCase {
 		$group = $this->make_group( 5, 'Alpha Group', 'public', 'https://example.org/groups/alpha-group/docs/' );
 
 		$GLOBALS['hc_test']['is_group']      = true;
-		$GLOBALS['hc_test']['current_group'] = $group;
+		hc_test_set_current_group( $group );
 
 		$this->assertSame(
 			'https://example.org/groups/alpha-group/docs/',
@@ -55,7 +55,7 @@ class GroupNavTest extends TestCase {
 		$other   = $this->make_group( 9, 'Beta Group', 'public', 'https://example.org/groups/beta-group/docs/' );
 
 		$GLOBALS['hc_test']['is_group']      = true;
-		$GLOBALS['hc_test']['current_group'] = $current;
+		hc_test_set_current_group( $current );
 
 		$this->assertSame(
 			'https://example.org/groups/beta-group/docs/',
@@ -98,7 +98,7 @@ class GroupNavTest extends TestCase {
 		$group = $this->make_group( 5, 'Alpha Group', 'public', 'https://example.org/groups/alpha-group/docs/' );
 
 		$GLOBALS['hc_test']['is_group']      = true;
-		$GLOBALS['hc_test']['current_group'] = $group;
+		hc_test_set_current_group( $group );
 
 		$html = $this->render_tabs_template();
 
@@ -169,6 +169,54 @@ class GroupNavTest extends TestCase {
 		$html = $this->render_tabs_template();
 
 		$this->assertStringNotContainsString( '/groups/', $html );
+	}
+
+	// -------------------------------------------------------------------------
+	// Sub-problem 3: invite-anyone nav restored for existing groups.
+	// -------------------------------------------------------------------------
+
+	public function test_invite_nav_registered_when_group_allows_member_invites() {
+		$group = $this->make_group( 5, 'Alpha Group', 'hidden' );
+
+		$GLOBALS['hc_test']['is_group']            = true;
+		hc_test_set_current_group( $group );
+		$GLOBALS['hc_test']['can_send_invites'][5] = true;
+		$GLOBALS['hc_test']['invite_access'][5]    = 'anyone';
+
+		$this->assertTrue( hc_custom_restore_invite_anyone_group_nav() );
+		$this->assertCount( 1, BP_Invite_Anyone::$instances );
+		$this->assertTrue( BP_Invite_Anyone::$instances[0]->registered );
+	}
+
+	public function test_invite_nav_not_registered_outside_group_context() {
+		$GLOBALS['hc_test']['is_group'] = false;
+
+		$this->assertFalse( hc_custom_restore_invite_anyone_group_nav() );
+		$this->assertCount( 0, BP_Invite_Anyone::$instances );
+	}
+
+	public function test_invite_nav_not_registered_when_user_cannot_send_invites() {
+		$group = $this->make_group( 5, 'Alpha Group', 'hidden' );
+
+		$GLOBALS['hc_test']['is_group']            = true;
+		hc_test_set_current_group( $group );
+		$GLOBALS['hc_test']['can_send_invites'][5] = false;
+		$GLOBALS['hc_test']['invite_access'][5]    = 'anyone';
+
+		$this->assertFalse( hc_custom_restore_invite_anyone_group_nav() );
+		$this->assertCount( 0, BP_Invite_Anyone::$instances );
+	}
+
+	public function test_invite_nav_not_registered_when_access_setting_disallows() {
+		$group = $this->make_group( 5, 'Alpha Group', 'hidden' );
+
+		$GLOBALS['hc_test']['is_group']            = true;
+		hc_test_set_current_group( $group );
+		$GLOBALS['hc_test']['can_send_invites'][5] = true;
+		$GLOBALS['hc_test']['invite_access'][5]    = 'noone';
+
+		$this->assertFalse( hc_custom_restore_invite_anyone_group_nav() );
+		$this->assertCount( 0, BP_Invite_Anyone::$instances );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/unit/GroupNavTest.php
+++ b/tests/unit/GroupNavTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Unit tests for the hc-custom group navigation fixes (issue #101):
+ *
+ * 1. The docs tabs on a single doc offer a way back to the owning group's
+ *    docs list.
+ * 2. The "[group]'s Docs" tab links to the CURRENT group's docs list (not a
+ *    relative URL that resolves to another group's doc).
+ * 3. The invite-anyone "Send Invites" tab is restored for existing groups on
+ *    BuddyPress 12+ when the group allows the current user to send invites.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class GroupNavTest extends TestCase {
+
+	protected function setUp(): void {
+		hc_test_reset_state();
+	}
+
+	private function make_group( $id, $name, $status = 'public', $docs_url = '' ) {
+		$group = (object) array(
+			'id'     => $id,
+			'name'   => $name,
+			'status' => $status,
+		);
+
+		$GLOBALS['hc_test']['groups'][ $id ] = $group;
+
+		if ( $docs_url ) {
+			$GLOBALS['hc_test']['group_docs_urls'][ $id ] = $docs_url;
+		}
+
+		return $group;
+	}
+
+	// -------------------------------------------------------------------------
+	// Sub-problem 2: group docs link must point at the current group.
+	// -------------------------------------------------------------------------
+
+	public function test_group_docs_url_returns_current_group_docs_url() {
+		$group = $this->make_group( 5, 'Alpha Group', 'public', 'https://example.org/groups/alpha-group/docs/' );
+
+		$GLOBALS['hc_test']['is_group']      = true;
+		$GLOBALS['hc_test']['current_group'] = $group;
+
+		$this->assertSame(
+			'https://example.org/groups/alpha-group/docs/',
+			hc_custom_get_group_docs_url()
+		);
+	}
+
+	public function test_group_docs_url_uses_explicit_group_over_current_group() {
+		$current = $this->make_group( 5, 'Alpha Group', 'public', 'https://example.org/groups/alpha-group/docs/' );
+		$other   = $this->make_group( 9, 'Beta Group', 'public', 'https://example.org/groups/beta-group/docs/' );
+
+		$GLOBALS['hc_test']['is_group']      = true;
+		$GLOBALS['hc_test']['current_group'] = $current;
+
+		$this->assertSame(
+			'https://example.org/groups/beta-group/docs/',
+			hc_custom_get_group_docs_url( $other )
+		);
+	}
+
+	public function test_group_docs_url_is_empty_when_no_group_available() {
+		$this->assertSame( '', hc_custom_get_group_docs_url() );
+	}
+
+	public function test_docs_tabs_template_is_overridden_with_hc_custom_copy() {
+		$upstream = '/srv/www/plugins/buddypress-docs/includes/templates/docs/tabs-legacy.php';
+
+		$located = hc_custom_bp_docs_tabs_template( $upstream, 'tabs-legacy.php' );
+
+		$this->assertStringEndsWith( 'hc-custom/includes/templates/docs/tabs-legacy.php', $located );
+		$this->assertFileExists( $located );
+	}
+
+	public function test_docs_tabs_template_override_leaves_other_templates_alone() {
+		$upstream = '/srv/www/plugins/buddypress-docs/includes/templates/docs/docs-loop.php';
+
+		$this->assertSame(
+			$upstream,
+			hc_custom_bp_docs_tabs_template( $upstream, 'docs-loop.php' )
+		);
+	}
+
+	public function test_docs_tabs_template_override_respects_theme_provided_template() {
+		$theme_template = '/srv/www/themes/some-theme/docs/tabs-legacy.php';
+
+		$this->assertSame(
+			$theme_template,
+			hc_custom_bp_docs_tabs_template( $theme_template, 'tabs-legacy.php' )
+		);
+	}
+
+	public function test_rendered_tabs_link_group_tab_to_current_group_docs() {
+		$group = $this->make_group( 5, 'Alpha Group', 'public', 'https://example.org/groups/alpha-group/docs/' );
+
+		$GLOBALS['hc_test']['is_group']      = true;
+		$GLOBALS['hc_test']['current_group'] = $group;
+
+		$html = $this->render_tabs_template();
+
+		$this->assertStringContainsString( 'href="https://example.org/groups/alpha-group/docs/"', $html );
+		$this->assertStringContainsString( 'Alpha Group', $html );
+		// The upstream bug produced a bare relative href="docs".
+		$this->assertStringNotContainsString( 'href="docs"', $html );
+	}
+
+	// -------------------------------------------------------------------------
+	// Sub-problem 1: single doc view links back to the owning group's docs.
+	// -------------------------------------------------------------------------
+
+	public function test_doc_group_docs_tab_returns_link_for_associated_group() {
+		$this->make_group( 7, 'Gamma Group', 'public', 'https://example.org/groups/gamma-group/docs/' );
+		$GLOBALS['hc_test']['doc_groups'][123] = 7;
+
+		$tab = hc_custom_get_doc_group_docs_tab( 123 );
+
+		$this->assertIsArray( $tab );
+		$this->assertSame( 'https://example.org/groups/gamma-group/docs/', $tab['url'] );
+		$this->assertStringContainsString( 'Gamma Group', $tab['label'] );
+	}
+
+	public function test_doc_group_docs_tab_is_null_when_doc_has_no_group() {
+		$GLOBALS['hc_test']['doc_groups'][123] = 0;
+
+		$this->assertNull( hc_custom_get_doc_group_docs_tab( 123 ) );
+	}
+
+	public function test_doc_group_docs_tab_is_null_for_hidden_group_non_member() {
+		$this->make_group( 7, 'Hidden Group', 'hidden', 'https://example.org/groups/hidden-group/docs/' );
+		$GLOBALS['hc_test']['doc_groups'][123]  = 7;
+		$GLOBALS['hc_test']['loggedin_user']    = 4;
+		$GLOBALS['hc_test']['memberships']      = array();
+
+		$this->assertNull( hc_custom_get_doc_group_docs_tab( 123 ) );
+	}
+
+	public function test_doc_group_docs_tab_returned_for_hidden_group_member() {
+		$this->make_group( 7, 'Hidden Group', 'hidden', 'https://example.org/groups/hidden-group/docs/' );
+		$GLOBALS['hc_test']['doc_groups'][123]      = 7;
+		$GLOBALS['hc_test']['loggedin_user']        = 4;
+		$GLOBALS['hc_test']['memberships']['4:7']   = true;
+
+		$tab = hc_custom_get_doc_group_docs_tab( 123 );
+
+		$this->assertIsArray( $tab );
+		$this->assertSame( 'https://example.org/groups/hidden-group/docs/', $tab['url'] );
+	}
+
+	public function test_rendered_tabs_include_back_link_on_single_doc_outside_group() {
+		$this->make_group( 7, 'Gamma Group', 'public', 'https://example.org/groups/gamma-group/docs/' );
+		$GLOBALS['hc_test']['doc_groups'][123] = 7;
+		$GLOBALS['hc_test']['is_group']        = false;
+		$GLOBALS['hc_test']['current_doc']     = (object) array( 'ID' => 123 );
+
+		$html = $this->render_tabs_template();
+
+		$this->assertStringContainsString( 'href="https://example.org/groups/gamma-group/docs/"', $html );
+		$this->assertStringContainsString( 'Gamma Group', $html );
+	}
+
+	public function test_rendered_tabs_have_no_group_link_for_doc_without_group() {
+		$GLOBALS['hc_test']['is_group']    = false;
+		$GLOBALS['hc_test']['current_doc'] = (object) array( 'ID' => 123 );
+
+		$html = $this->render_tabs_template();
+
+		$this->assertStringNotContainsString( '/groups/', $html );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers.
+	// -------------------------------------------------------------------------
+
+	private function render_tabs_template() {
+		$template = dirname( __DIR__, 2 ) . '/plugins/hc-custom/includes/templates/docs/tabs-legacy.php';
+		$this->assertFileExists( $template );
+
+		$show_create_button = false;
+
+		ob_start();
+		include $template;
+		return ob_get_clean();
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -359,3 +359,4 @@ if ( ! function_exists( 'wp_remote_request' ) ) {
 
 require_once __DIR__ . '/xprofile-html-fix-loader.php';
 require_once __DIR__ . '/group-permissions-loader.php';
+require_once __DIR__ . '/group-nav-loader.php';

--- a/tests/unit/group-nav-loader.php
+++ b/tests/unit/group-nav-loader.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Loader for group navigation unit tests.
+ *
+ * Stubs the WordPress/BuddyPress functions used by the hc-custom group
+ * navigation code, then loads the real plugin files under test. Stub
+ * behaviour is driven by $GLOBALS['hc_test'] state so each test can set up
+ * its own scenario without any live WordPress installation.
+ */
+
+if ( ! isset( $GLOBALS['hc_test'] ) ) {
+	$GLOBALS['hc_test'] = array();
+}
+
+/**
+ * Reset the shared stub state to a known baseline.
+ */
+function hc_test_reset_state() {
+	$GLOBALS['hc_test'] = array(
+		'is_group'         => false,
+		'current_group'    => null,
+		'group_docs_urls'  => array(),
+		'doc_groups'       => array(),
+		'groups'           => array(),
+		'memberships'      => array(),
+		'loggedin_user'    => 1,
+		'can_moderate'     => false,
+		'can_send_invites' => array(),
+		'invite_access'    => array(),
+	);
+
+	// Clear the group-permissions suite's mock store so its bridged stubs
+	// fall through to the hc_test state set up above.
+	$GLOBALS['_hc_mock'] = array();
+
+	BP_Invite_Anyone::$instances = array();
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		// no-op for unit tests.
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( '_e' ) ) {
+	function _e( $text, $domain = 'default' ) {
+		echo $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $url ) {
+		return (string) $url;
+	}
+}
+
+if ( ! defined( 'BP_DOCS_SLUG' ) ) {
+	define( 'BP_DOCS_SLUG', 'docs' );
+}
+
+// --- BuddyPress / BuddyPress Docs stubs --------------------------------------
+
+if ( ! function_exists( 'bp_is_group' ) ) {
+	function bp_is_group() {
+		return ! empty( $GLOBALS['hc_test']['is_group'] );
+	}
+}
+
+if ( ! function_exists( 'groups_get_current_group' ) ) {
+	function groups_get_current_group() {
+		return $GLOBALS['hc_test']['current_group'] ?? null;
+	}
+}
+
+if ( ! function_exists( 'bp_get_current_group_id' ) ) {
+	function bp_get_current_group_id() {
+		$group = $GLOBALS['hc_test']['current_group'] ?? null;
+		return empty( $group->id ) ? 0 : (int) $group->id;
+	}
+}
+
+if ( ! function_exists( 'bp_get_current_group_name' ) ) {
+	function bp_get_current_group_name() {
+		$group = $GLOBALS['hc_test']['current_group'] ?? null;
+		return empty( $group->name ) ? '' : $group->name;
+	}
+}
+
+if ( ! function_exists( 'bp_docs_get_group_docs_url' ) ) {
+	/**
+	 * Returns the configured docs URL for a group, resolving the group the
+	 * same way the real function does (explicit object/ID, else current).
+	 */
+	function bp_docs_get_group_docs_url( $group = null ) {
+		if ( ! $group ) {
+			$group = groups_get_current_group();
+		}
+		$group_id = is_object( $group ) ? ( $group->id ?? 0 ) : (int) $group;
+		if ( ! $group_id ) {
+			return '';
+		}
+		return $GLOBALS['hc_test']['group_docs_urls'][ $group_id ] ?? '';
+	}
+}
+
+if ( ! function_exists( 'bp_docs_get_associated_group_id' ) ) {
+	function bp_docs_get_associated_group_id( $doc_id ) {
+		return $GLOBALS['hc_test']['doc_groups'][ $doc_id ] ?? 0;
+	}
+}
+
+if ( ! function_exists( 'groups_get_group' ) ) {
+	function groups_get_group( $args ) {
+		$group_id = is_array( $args ) ? ( $args['group_id'] ?? 0 ) : (int) $args;
+		return $GLOBALS['hc_test']['groups'][ $group_id ] ?? (object) array();
+	}
+}
+
+if ( ! function_exists( 'groups_is_user_member' ) ) {
+	function groups_is_user_member( $user_id, $group_id ) {
+		return ! empty( $GLOBALS['hc_test']['memberships'][ $user_id . ':' . $group_id ] );
+	}
+}
+
+if ( ! function_exists( 'bp_loggedin_user_id' ) ) {
+	function bp_loggedin_user_id() {
+		return $GLOBALS['hc_test']['loggedin_user'] ?? 0;
+	}
+}
+
+if ( ! function_exists( 'bp_current_user_can' ) ) {
+	function bp_current_user_can( $capability ) {
+		if ( 'bp_moderate' === $capability ) {
+			return ! empty( $GLOBALS['hc_test']['can_moderate'] );
+		}
+		return false;
+	}
+}
+
+if ( ! function_exists( 'bp_groups_user_can_send_invites' ) ) {
+	function bp_groups_user_can_send_invites( $group_id = 0, $user_id = 0 ) {
+		return ! empty( $GLOBALS['hc_test']['can_send_invites'][ $group_id ] );
+	}
+}
+
+if ( ! function_exists( 'invite_anyone_group_invite_access_test' ) ) {
+	function invite_anyone_group_invite_access_test( $group_id = 0, $user_id = 0 ) {
+		return $GLOBALS['hc_test']['invite_access'][ $group_id ] ?? 'noone';
+	}
+}
+
+// Template tags used by the overridden docs tabs template.
+
+if ( ! function_exists( 'bp_docs_is_global_directory' ) ) {
+	function bp_docs_is_global_directory() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'bp_docs_archive_link' ) ) {
+	function bp_docs_archive_link() {
+		echo 'https://example.org/docs/';
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in() {
+		return ! empty( $GLOBALS['hc_test']['loggedin_user'] );
+	}
+}
+
+if ( ! function_exists( 'bp_is_current_action' ) ) {
+	function bp_is_current_action( $action ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'bp_docs_mydocs_started_link' ) ) {
+	function bp_docs_mydocs_started_link() {
+		echo 'https://example.org/docs/started/';
+	}
+}
+
+if ( ! function_exists( 'bp_docs_mydocs_edited_link' ) ) {
+	function bp_docs_mydocs_edited_link() {
+		echo 'https://example.org/docs/edited/';
+	}
+}
+
+if ( ! function_exists( 'bp_is_active' ) ) {
+	function bp_is_active( $component ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'bp_docs_is_mygroups_docs' ) ) {
+	function bp_docs_is_mygroups_docs() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'bp_docs_mygroups_link' ) ) {
+	function bp_docs_mygroups_link() {
+		echo 'https://example.org/docs/mygroups/';
+	}
+}
+
+if ( ! function_exists( 'bp_docs_create_button' ) ) {
+	function bp_docs_create_button() {
+		// no-op for unit tests.
+	}
+}
+
+if ( ! function_exists( 'bp_docs_is_existing_doc' ) ) {
+	function bp_docs_is_existing_doc() {
+		return ! empty( $GLOBALS['hc_test']['current_doc'] );
+	}
+}
+
+if ( ! function_exists( 'bp_docs_get_current_doc' ) ) {
+	function bp_docs_get_current_doc() {
+		return $GLOBALS['hc_test']['current_doc'] ?? null;
+	}
+}
+
+/**
+ * Test double for the invite-anyone group extension. Records instantiation
+ * and registration so tests can assert whether the nav item was restored.
+ */
+if ( ! class_exists( 'BP_Invite_Anyone' ) ) {
+	class BP_Invite_Anyone {
+		public static $instances = array();
+		public $registered        = false;
+
+		public function __construct() {
+			self::$instances[] = $this;
+		}
+
+		public function _register() {
+			$this->registered = true;
+		}
+	}
+}
+
+// Load the real hc-custom code under test.
+require_once __DIR__ . '/../../plugins/hc-custom/includes/buddypress-docs.php';

--- a/tests/unit/group-nav-loader.php
+++ b/tests/unit/group-nav-loader.php
@@ -29,11 +29,25 @@ function hc_test_reset_state() {
 		'invite_access'    => array(),
 	);
 
+	// The shared bootstrap's bp_get_current_group_id() stub reads this.
+	$GLOBALS['_mock_current_group_id'] = 0;
+
 	// Clear the group-permissions suite's mock store so its bridged stubs
 	// fall through to the hc_test state set up above.
 	$GLOBALS['_hc_mock'] = array();
 
 	BP_Invite_Anyone::$instances = array();
+}
+
+/**
+ * Set the current group for both the hc_test state and the shared
+ * bootstrap's bp_get_current_group_id() stub.
+ *
+ * @param object|null $group Group object, or null to clear.
+ */
+function hc_test_set_current_group( $group ) {
+	$GLOBALS['hc_test']['current_group'] = $group;
+	$GLOBALS['_mock_current_group_id']   = empty( $group->id ) ? 0 : (int) $group->id;
 }
 
 if ( ! function_exists( 'add_filter' ) ) {
@@ -262,3 +276,4 @@ if ( ! class_exists( 'BP_Invite_Anyone' ) ) {
 
 // Load the real hc-custom code under test.
 require_once __DIR__ . '/../../plugins/hc-custom/includes/buddypress-docs.php';
+require_once __DIR__ . '/../../plugins/hc-custom/includes/invite-anyone.php';

--- a/tests/unit/group-permissions-loader.php
+++ b/tests/unit/group-permissions-loader.php
@@ -112,7 +112,9 @@ if ( ! function_exists( 'current_user_can' ) ) {
 
 if ( ! function_exists( 'bp_is_group' ) ) {
 	function bp_is_group() {
-		return (bool) _hc_mock( 'is_group', false );
+		// Shared across suites: falls back to the hc_test store used by the
+		// group-nav loader when no _hc_mock value is configured.
+		return (bool) _hc_mock( 'is_group', ! empty( $GLOBALS['hc_test']['is_group'] ) );
 	}
 }
 
@@ -124,7 +126,9 @@ if ( ! function_exists( 'bp_get_current_group_id' ) ) {
 
 if ( ! function_exists( 'bp_loggedin_user_id' ) ) {
 	function bp_loggedin_user_id() {
-		return (int) _hc_mock( 'current_user_id', 0 );
+		// Shared across suites: falls back to the hc_test store used by the
+		// group-nav loader when no _hc_mock value is configured.
+		return (int) _hc_mock( 'current_user_id', $GLOBALS['hc_test']['loggedin_user'] ?? 0 );
 	}
 }
 
@@ -142,7 +146,12 @@ if ( ! function_exists( 'groups_is_user_mod' ) ) {
 
 if ( ! function_exists( 'groups_is_user_member' ) ) {
 	function groups_is_user_member( $user_id, $group_id ) {
-		return in_array( "$user_id:$group_id", _hc_mock( 'group_members', array() ), true );
+		// Shared across suites: falls back to the hc_test store used by the
+		// group-nav loader when no _hc_mock value is configured.
+		if ( isset( $GLOBALS['_hc_mock']['group_members'] ) ) {
+			return in_array( "$user_id:$group_id", $GLOBALS['_hc_mock']['group_members'], true );
+		}
+		return ! empty( $GLOBALS['hc_test']['memberships'][ "$user_id:$group_id" ] );
 	}
 }
 
@@ -163,7 +172,9 @@ if ( ! function_exists( 'groups_get_user_groups' ) ) {
 
 if ( ! function_exists( 'groups_get_current_group' ) ) {
 	function groups_get_current_group() {
-		return _hc_mock( 'current_group', null );
+		// Shared across suites: falls back to the hc_test store used by the
+		// group-nav loader when no _hc_mock value is configured.
+		return _hc_mock( 'current_group', $GLOBALS['hc_test']['current_group'] ?? null );
 	}
 }
 


### PR DESCRIPTION
Fixes the three group-navigation problems reported in #101.

## 1. "[group]'s Docs" tab pointed at the wrong group

The legacy buddypress-docs tabs template (`tabs-legacy.php`) calls `esc_url( bp_get_group_url( ... ) )` without echoing the result, so the group tab's href is just the relative string `docs`. From a group's docs page that resolves to `/groups/{slug}/docs/docs`, which buddypress-docs then treats as a doc-slug lookup and can land the user on a doc belonging to a completely different group.

hc-custom now overrides the tabs template through the `bp_docs_locate_template` filter with a corrected copy that builds the tab URL from `bp_docs_get_group_docs_url()` for the current group. Theme-provided overrides of the same template are respected.

## 2. No way back to a group's docs list from a single doc

Single docs render at the global `/docs/{slug}` URL, outside the group context, so the tabs only offered "All Docs" / "Started By Me" / "Edited By Me". The overridden template now adds a "[group]'s Docs" tab on single-doc views, resolved from the doc's associated group. Hidden groups are not revealed to non-members.

## 3. Send Invites tab missing from existing groups

Production runs BuddyPress 10.6; dev runs 14.5. Invite Anyone computes `enable_nav_item()` in the `BP_Invite_Anyone` constructor, which BuddyPress instantiates at `bp_init:11` — but since the BuddyPress 12 rewrites API the requested group is not resolved until `bp_parse_query`, so `bp_get_current_group_id()` is 0 at that point. The capability check fails and the extension registers with access/visibility `noone`, removing the Send Invites tab (and page) from every existing group. Hidden invite-only groups were left with no way to invite members at all.

hc-custom now re-registers the extension at `bp_actions:7`, once the current group is known, so Invite Anyone's own access rules (the group's invite status plus the invite-anyone access-level test) are evaluated against the real group.

## Tests

Adds `tests/unit/GroupNavTest.php` (17 tests) covering the group-docs URL builder, the template override, the rendered tab markup in both group and single-doc contexts, the hidden-group guard, and the conditions under which the invite tab is restored. Full unit suite: 43 tests, 81 assertions, all passing.