### PR TITLE
Fix group admin permissions on group forums and events

### DIFF
--- a/plugins/hc-custom/includes/bbpress.php
+++ b/plugins/hc-custom/includes/bbpress.php
@@ -285,9 +285,107 @@ function hcommons_tinymce_buttons( $buttons ) {
 add_filter( 'mce_buttons', 'hcommons_tinymce_buttons', 21 );
 
 /**
+ * Resolve the BuddyPress group IDs associated with a bbPress forum, topic or reply.
+ *
+ * @param int $post_id ID of the forum, topic or reply being checked.
+ * @return array Group IDs the post's forum is attached to.
+ */
+function hc_custom_get_group_ids_for_forum_post( $post_id ) {
+	if ( empty( $post_id ) || ! function_exists( 'bbp_get_forum_group_ids' ) ) {
+		return array();
+	}
+
+	$post = get_post( $post_id );
+	if ( empty( $post ) ) {
+		return array();
+	}
+
+	if ( bbp_get_forum_post_type() === $post->post_type ) {
+		$forum_id = $post->ID;
+	} elseif ( bbp_get_topic_post_type() === $post->post_type ) {
+		$forum_id = bbp_get_topic_forum_id( $post->ID );
+	} elseif ( bbp_get_reply_post_type() === $post->post_type ) {
+		$forum_id = bbp_get_reply_forum_id( $post->ID );
+	} else {
+		return array();
+	}
+
+	if ( empty( $forum_id ) ) {
+		return array();
+	}
+
+	return array_filter( array_map( 'intval', (array) bbp_get_forum_group_ids( $forum_id ) ) );
+}
+
+/**
+ * Restore group forum moderation capabilities for group admins and mods.
+ *
+ * bbPress's BBP_Forums_Group_Extension::map_group_forum_meta_caps() is only
+ * hooked when the extension is constructed inside a group forum request. Since
+ * BuddyPress 12 the request is parsed on 'bp_parse_query', which runs after
+ * group extensions are constructed on 'bp_init', so the stock mapping never
+ * attaches and group admins/mods lose their moderation capabilities. This
+ * reinstates the same mapping, resolving group context from the object being
+ * checked and falling back to the current group.
+ *
+ * @param array  $caps    Mapped capabilities.
+ * @param string $cap     Capability being checked.
+ * @param int    $user_id ID of the user being checked.
+ * @param array  $args    Additional args (usually the object ID).
+ * @return array Mapped capabilities.
+ */
+function hc_custom_map_group_forum_meta_caps( $caps, $cap, $user_id, $args ) {
+	$member_caps = array( 'read_forum', 'publish_replies', 'publish_topics', 'read_hidden_forums', 'read_private_forums' );
+	$mod_caps    = array( 'moderate', 'edit_topic', 'edit_reply', 'view_trash', 'edit_others_replies', 'edit_others_topics' );
+	$admin_caps  = array( 'delete_topic', 'delete_reply' );
+
+	if ( ! in_array( $cap, array_merge( $member_caps, $mod_caps, $admin_caps ), true ) ) {
+		return $caps;
+	}
+
+	// Resolve the groups attached to the forum of the object being checked.
+	$group_ids = hc_custom_get_group_ids_for_forum_post( isset( $args[0] ) ? $args[0] : 0 );
+
+	// For primitive caps checked without an object, fall back to the current group.
+	if ( empty( $group_ids ) && empty( $args[0] ) && bp_is_group() && bp_get_current_group_id() ) {
+		$group_ids = array( bp_get_current_group_id() );
+	}
+
+	if ( empty( $group_ids ) ) {
+		return $caps;
+	}
+
+	$is_member = false;
+	$is_mod    = false;
+	$is_admin  = false;
+	$is_banned = false;
+
+	foreach ( $group_ids as $group_id ) {
+		$is_member = $is_member || (bool) groups_is_user_member( $user_id, $group_id );
+		$is_mod    = $is_mod || (bool) groups_is_user_mod( $user_id, $group_id );
+		$is_admin  = $is_admin || (bool) groups_is_user_admin( $user_id, $group_id );
+		$is_banned = $is_banned || (bool) groups_is_user_banned( $user_id, $group_id );
+	}
+
+	if ( in_array( $cap, $member_caps, true ) ) {
+		if ( $is_banned ) {
+			$caps = array( 'do_not_allow' );
+		} elseif ( $is_member || $is_mod || $is_admin ) {
+			$caps = array( 'participate' );
+		}
+	} elseif ( in_array( $cap, $mod_caps, true ) && ( $is_mod || $is_admin ) ) {
+		$caps = array( 'participate' );
+	} elseif ( in_array( $cap, $admin_caps, true ) && $is_admin ) {
+		$caps = array( 'participate' );
+	}
+
+	return $caps;
+}
+add_filter( 'bbp_map_meta_caps', 'hc_custom_map_group_forum_meta_caps', 12, 4 );
+
+/**
  * Filter who can edit forum topics.
  *
- * @uses mla_is_group_committee()
  * @param  array $array Array of the links to modify.
  * @return array Modified array of items.
  */
@@ -297,15 +395,18 @@ function hcommons_topic_admin_links( $array ) {
 		return $array;
 	}
 
-	// Committee admins can edit any post in their group.
-	if ( mla_is_group_committee( bp_get_current_group_id() ) && groups_is_user_admin( get_current_user_id(), bp_get_current_group_id() ) ) {
+	$user_id  = get_current_user_id();
+	$group_id = bp_get_current_group_id();
+
+	// Group admins and mods can moderate any post in their group.
+	if ( ! empty( $group_id ) && ( groups_is_user_admin( $user_id, $group_id ) || groups_is_user_mod( $user_id, $group_id ) ) ) {
 		return $array;
 	}
 
 	// All other users can only edit their own posts.
 	if (
 		isset( $array['edit'] ) &&
-		get_current_user_id() !== bbp_get_topic_author_id( bbp_get_topic_id() )
+		$user_id !== bbp_get_topic_author_id( bbp_get_topic_id() )
 	) {
 		unset( $array['edit'] );
 	}
@@ -317,7 +418,6 @@ add_filter( 'bbp_topic_admin_links', 'hcommons_topic_admin_links' );
 /**
  * Filter who can edit forum replies.
  *
- * @uses mla_is_group_committee()
  * @param  array $array Array of the links to modify.
  * @return array Modified array of items.
  */
@@ -327,15 +427,18 @@ function hcommons_reply_admin_links( $array ) {
 		return $array;
 	}
 
-	// Committee admins can edit any post in their group.
-	if ( mla_is_group_committee( bp_get_current_group_id() ) && groups_is_user_admin( get_current_user_id(), bp_get_current_group_id() ) ) {
+	$user_id  = get_current_user_id();
+	$group_id = bp_get_current_group_id();
+
+	// Group admins and mods can moderate any post in their group.
+	if ( ! empty( $group_id ) && ( groups_is_user_admin( $user_id, $group_id ) || groups_is_user_mod( $user_id, $group_id ) ) ) {
 		return $array;
 	}
 
 	// All other users can only edit their own posts.
 	if (
 		isset( $array['edit'] ) &&
-		get_current_user_id() !== bbp_get_reply_author_id( bbp_get_reply_id() )
+		$user_id !== bbp_get_reply_author_id( bbp_get_reply_id() )
 	) {
 		unset( $array['edit'] );
 	}

--- a/plugins/hc-custom/includes/bp-event-organiser.php
+++ b/plugins/hc-custom/includes/bp-event-organiser.php
@@ -97,6 +97,10 @@ function hc_custom_bpeo_group_event_meta_cap( $caps, $cap, $user_id, $args ) {
 	}
 
 	// Some caps do not expect a specific event to be passed to the filter.
+	$event        = null;
+	$event_groups = array();
+	$user_groups  = array( 'groups' => array() );
+
 	$primitive_caps = array( 'read_events', 'read_private_events', 'edit_events', 'edit_others_events', 'publish_events', 'delete_events', 'delete_others_events', 'manage_event_categories', 'connect_event_to_group' );
 	if ( ! in_array( $cap, $primitive_caps ) ) {
 		$event = get_post( $args[0] );
@@ -120,7 +124,7 @@ function hc_custom_bpeo_group_event_meta_cap( $caps, $cap, $user_id, $args ) {
 				return $caps;
 			}
 
-			if ( 'private' !== $event->post_status ) {
+			if ( 'private' !== ( is_object( $event ) ? $event->post_status : null ) ) {
 				// EO uses 'read', which doesn't include non-logged-in users.
 				$caps = array( 'exist' );
 
@@ -128,8 +132,24 @@ function hc_custom_bpeo_group_event_meta_cap( $caps, $cap, $user_id, $args ) {
 				$caps = array( 'read' );
 			}
 
-			// @todo group admins / mods permissions
+			break;
+
 		case 'edit_event':
+		case 'delete_event':
+			// Group admins can edit and delete any event connected to their
+			// group; group mods can edit.
+			foreach ( $event_groups as $event_group_id ) {
+				if ( groups_is_user_admin( $user_id, $event_group_id ) ) {
+					$caps = array( 'exist' );
+					break;
+				}
+
+				if ( 'edit_event' === $cap && groups_is_user_mod( $user_id, $event_group_id ) ) {
+					$caps = array( 'exist' );
+					break;
+				}
+			}
+
 			break;
 
 		case 'connect_event_to_group':
@@ -152,6 +172,97 @@ function hc_custom_bpeo_group_event_meta_cap( $caps, $cap, $user_id, $args ) {
 	return $caps;
 }
 add_filter( 'map_meta_cap', 'hc_custom_bpeo_group_event_meta_cap', 20, 5 );
+
+/**
+ * Register the events subnav (Calendar / Upcoming / Manage / New Event) for the
+ * current group.
+ *
+ * BP Event Organiser registers this subnav from its group extension
+ * constructor, which runs on 'bp_init'. Since BuddyPress 12 the request is
+ * parsed on 'bp_parse_query', which runs later, so bp_is_group() is false at
+ * construction time and the subnav is never registered — leaving group members
+ * without the "New Event" button. This re-registers the subnav once the group
+ * context is available.
+ */
+function hc_custom_bpeo_register_group_events_subnav() {
+	if ( ! function_exists( 'bpeo_get_group_permalink' ) || ! bp_is_group() ) {
+		return;
+	}
+
+	$group = groups_get_current_group();
+	if ( empty( $group->slug ) ) {
+		return;
+	}
+
+	$parent_slug = $group->slug . '_events';
+
+	// Bail if the subnav has already been registered (e.g. fixed upstream).
+	$existing = buddypress()->groups->nav->get_secondary( array( 'parent_slug' => $parent_slug ), false );
+	if ( ! empty( $existing ) ) {
+		return;
+	}
+
+	// Routing is handled by the Events group extension screen, so the subnav
+	// items are links only and never dispatch their own screen function.
+	$default_params = array(
+		'parent_url'        => bpeo_get_group_permalink(),
+		'parent_slug'       => $parent_slug,
+		'screen_function'   => '__return_false',
+		'show_in_admin_bar' => true,
+	);
+
+	$sub_nav = array();
+
+	$sub_nav[] = array_merge(
+		array(
+			'name'            => __( 'Calendar', 'bp-event-organiser' ),
+			'slug'            => 'calendar',
+			'user_has_access' => ! empty( $group->is_user_member ),
+			'position'        => 0,
+			'link'            => bpeo_get_group_permalink(),
+		),
+		$default_params
+	);
+
+	$sub_nav[] = array_merge(
+		array(
+			'name'            => __( 'Upcoming', 'bp-event-organiser' ),
+			'slug'            => 'upcoming',
+			'user_has_access' => ! empty( $group->is_user_member ),
+			'position'        => 0,
+			'link'            => bpeo_get_group_permalink() . 'upcoming/',
+		),
+		$default_params
+	);
+
+	$sub_nav[] = array_merge(
+		array(
+			'name'            => __( 'Manage', 'bp-event-organiser' ),
+			'slug'            => 'manage',
+			'user_has_access' => (bool) groups_is_user_admin( bp_loggedin_user_id(), $group->id ),
+			'position'        => 0,
+			'link'            => trailingslashit( bp_get_group_permalink( $group ) . 'admin/' . bpeo_get_events_slug() ),
+		),
+		$default_params
+	);
+
+	if ( current_user_can( 'connect_event_to_group', $group->id ) ) {
+		$sub_nav[] = array_merge(
+			array(
+				'name'            => __( 'New Event', 'bp-event-organiser' ),
+				'slug'            => bpeo_get_events_new_slug(),
+				'user_has_access' => ! empty( $group->is_user_member ),
+				'position'        => 99,
+			),
+			$default_params
+		);
+	}
+
+	foreach ( $sub_nav as $nav ) {
+		bp_core_new_subnav_item( $nav, 'groups' );
+	}
+}
+add_action( 'bp_actions', 'hc_custom_bpeo_register_group_events_subnav', 7 );
 
 /**
  * Create activity on event save.

--- a/tests/unit/BpeoGroupEventCapsTest.php
+++ b/tests/unit/BpeoGroupEventCapsTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for hc_custom_bpeo_group_event_meta_cap(): group admins must be able to
+ * edit and delete events connected to their groups; existing read/connect
+ * behaviour must be preserved.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class BpeoGroupEventCapsTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['_hc_mock'] = array();
+	}
+
+	/**
+	 * Configure an event (post) connected to a group.
+	 */
+	private function setUpGroupEvent( $event_id, $group_id, $status = 'publish' ) {
+		$event              = new stdClass();
+		$event->ID          = $event_id;
+		$event->post_type   = 'event';
+		$event->post_status = $status;
+
+		$GLOBALS['_hc_mock']['posts']        = array( $event_id => $event );
+		$GLOBALS['_hc_mock']['event_groups'] = array( $event_id => array( $group_id ) );
+	}
+
+	public function test_group_admin_can_edit_group_event() {
+		$this->setUpGroupEvent( 400, 30 );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '5:30' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'edit_others_events' ), 'edit_event', 5, array( 400 ) );
+
+		$this->assertSame( array( 'exist' ), $caps );
+	}
+
+	public function test_group_admin_can_delete_group_event() {
+		$this->setUpGroupEvent( 401, 31 );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '6:31' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'delete_others_events' ), 'delete_event', 6, array( 401 ) );
+
+		$this->assertSame( array( 'exist' ), $caps );
+	}
+
+	public function test_group_mod_can_edit_group_event() {
+		$this->setUpGroupEvent( 402, 32 );
+		$GLOBALS['_hc_mock']['group_mods'] = array( '7:32' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'edit_others_events' ), 'edit_event', 7, array( 402 ) );
+
+		$this->assertSame( array( 'exist' ), $caps );
+	}
+
+	public function test_group_mod_cannot_delete_group_event() {
+		$this->setUpGroupEvent( 403, 33 );
+		$GLOBALS['_hc_mock']['group_mods'] = array( '8:33' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'delete_others_events' ), 'delete_event', 8, array( 403 ) );
+
+		$this->assertSame( array( 'delete_others_events' ), $caps );
+	}
+
+	public function test_plain_member_cannot_edit_group_event() {
+		$this->setUpGroupEvent( 404, 34 );
+		$GLOBALS['_hc_mock']['group_members'] = array( '9:34' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'edit_others_events' ), 'edit_event', 9, array( 404 ) );
+
+		$this->assertSame( array( 'edit_others_events' ), $caps );
+	}
+
+	public function test_event_without_groups_is_unchanged() {
+		$event              = new stdClass();
+		$event->ID          = 405;
+		$event->post_type   = 'event';
+		$event->post_status = 'publish';
+
+		$GLOBALS['_hc_mock']['posts']        = array( 405 => $event );
+		$GLOBALS['_hc_mock']['event_groups'] = array( 405 => array() );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '10:35' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'edit_others_events' ), 'edit_event', 10, array( 405 ) );
+
+		$this->assertSame( array( 'edit_others_events' ), $caps );
+	}
+
+	public function test_group_member_can_connect_event_to_group() {
+		$GLOBALS['_hc_mock']['group_members'] = array( '11:36' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'connect_event_to_group' ), 'connect_event_to_group', 11, array( 36 ) );
+
+		$this->assertSame( array( 'read' ), $caps );
+	}
+
+	public function test_non_member_cannot_connect_event_to_group() {
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'connect_event_to_group' ), 'connect_event_to_group', 12, array( 37 ) );
+
+		$this->assertSame( array( 'connect_event_to_group' ), $caps );
+	}
+
+	public function test_admin_mod_connection_setting_restricts_members() {
+		$GLOBALS['_hc_mock']['group_members']  = array( '13:38' );
+		$GLOBALS['_hc_mock']['group_min_role'] = array( 38 => 'admin_mod' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'connect_event_to_group' ), 'connect_event_to_group', 13, array( 38 ) );
+
+		$this->assertSame( array( 'connect_event_to_group' ), $caps );
+	}
+
+	public function test_private_event_readable_by_fellow_group_member() {
+		$this->setUpGroupEvent( 406, 39, 'private' );
+		$GLOBALS['_hc_mock']['user_groups'] = array( 14 => array( 39 ) );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'read_private_posts' ), 'read_event', 14, array( 406 ) );
+
+		$this->assertSame( array( 'read' ), $caps );
+	}
+
+	public function test_public_event_readable_by_anyone() {
+		$this->setUpGroupEvent( 407, 40, 'publish' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'read' ), 'read_event', 15, array( 407 ) );
+
+		$this->assertSame( array( 'exist' ), $caps );
+	}
+
+	public function test_non_event_cap_is_unchanged() {
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'edit_posts' ), 'edit_post', 16, array( 1 ) );
+
+		$this->assertSame( array( 'edit_posts' ), $caps );
+	}
+}

--- a/tests/unit/BpeoGroupEventsSubnavTest.php
+++ b/tests/unit/BpeoGroupEventsSubnavTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for hc_custom_bpeo_register_group_events_subnav(): the group events
+ * subnav (Calendar / Upcoming / Manage / New Event) must be registered once
+ * group context is available, since BP Event Organiser's own registration runs
+ * too early on BuddyPress 12+.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class BpeoGroupEventsSubnavTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['_hc_mock']              = array();
+		$GLOBALS['_hc_registered_subnav'] = array();
+	}
+
+	/**
+	 * Configure a current group with the given membership flags.
+	 */
+	private function setUpCurrentGroup( $is_member = true ) {
+		$group                 = new stdClass();
+		$group->id             = 50;
+		$group->slug           = 'test-group';
+		$group->is_user_member = $is_member;
+
+		$GLOBALS['_hc_mock']['is_group']         = true;
+		$GLOBALS['_hc_mock']['current_group']    = $group;
+		$GLOBALS['_hc_mock']['current_group_id'] = 50;
+	}
+
+	/**
+	 * Collect the slugs registered by the function under test.
+	 */
+	private function registeredSlugs() {
+		return array_map(
+			function ( $item ) {
+				return $item['args']['slug'];
+			},
+			$GLOBALS['_hc_registered_subnav']
+		);
+	}
+
+	public function test_no_subnav_registered_outside_group_context() {
+		$GLOBALS['_hc_mock']['is_group'] = false;
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertSame( array(), $GLOBALS['_hc_registered_subnav'] );
+	}
+
+	public function test_no_duplicate_registration_when_subnav_already_exists() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['existing_secondary_nav'] = array( (object) array( 'slug' => 'calendar' ) );
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertSame( array(), $GLOBALS['_hc_registered_subnav'] );
+	}
+
+	public function test_member_who_can_connect_gets_new_event_item() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['user_can'] = array( 'connect_event_to_group' => true );
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$slugs = $this->registeredSlugs();
+		$this->assertContains( 'calendar', $slugs );
+		$this->assertContains( 'upcoming', $slugs );
+		$this->assertContains( 'new', $slugs );
+	}
+
+	public function test_member_who_cannot_connect_does_not_get_new_event_item() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['user_can'] = array( 'connect_event_to_group' => false );
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$slugs = $this->registeredSlugs();
+		$this->assertContains( 'calendar', $slugs );
+		$this->assertContains( 'upcoming', $slugs );
+		$this->assertNotContains( 'new', $slugs );
+	}
+
+	public function test_subnav_items_registered_for_groups_component_under_events_parent() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['user_can'] = array( 'connect_event_to_group' => true );
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertNotEmpty( $GLOBALS['_hc_registered_subnav'] );
+		foreach ( $GLOBALS['_hc_registered_subnav'] as $item ) {
+			$this->assertSame( 'groups', $item['component'] );
+			$this->assertSame( 'test-group_events', $item['args']['parent_slug'] );
+		}
+	}
+
+	public function test_group_admin_gets_manage_item() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['current_user_id'] = 5;
+		$GLOBALS['_hc_mock']['group_admins']    = array( '5:50' );
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$manage = null;
+		foreach ( $GLOBALS['_hc_registered_subnav'] as $item ) {
+			if ( 'manage' === $item['args']['slug'] ) {
+				$manage = $item;
+			}
+		}
+
+		$this->assertNotNull( $manage );
+		$this->assertTrue( (bool) $manage['args']['user_has_access'] );
+	}
+
+	public function test_non_admin_does_not_have_access_to_manage_item() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['current_user_id'] = 6;
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$manage = null;
+		foreach ( $GLOBALS['_hc_registered_subnav'] as $item ) {
+			if ( 'manage' === $item['args']['slug'] ) {
+				$manage = $item;
+			}
+		}
+
+		$this->assertNotNull( $manage );
+		$this->assertFalse( (bool) $manage['args']['user_has_access'] );
+	}
+}

--- a/tests/unit/ForumAdminLinksTest.php
+++ b/tests/unit/ForumAdminLinksTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests for hcommons_topic_admin_links() and hcommons_reply_admin_links():
+ * group admins and mods must keep the full set of moderation links, not just
+ * MLA committee admins.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class ForumAdminLinksTest extends TestCase {
+
+	private $links;
+
+	protected function setUp(): void {
+		$GLOBALS['_hc_mock'] = array();
+
+		$this->links = array(
+			'edit'  => '<a href="#">Edit</a>',
+			'close' => '<a href="#">Close</a>',
+			'stick' => '<a href="#">Stick</a>',
+			'trash' => '<a href="#">Trash</a>',
+			'reply' => '<a href="#">Reply</a>',
+		);
+	}
+
+	public function test_super_admin_keeps_all_topic_links() {
+		$GLOBALS['_hc_mock']['is_super_admin'] = true;
+
+		$this->assertSame( $this->links, hcommons_topic_admin_links( $this->links ) );
+	}
+
+	public function test_group_admin_keeps_all_topic_links() {
+		$GLOBALS['_hc_mock']['current_user_id']  = 5;
+		$GLOBALS['_hc_mock']['current_group_id'] = 10;
+		$GLOBALS['_hc_mock']['group_admins']     = array( '5:10' );
+		$GLOBALS['_hc_mock']['topic_id']         = 200;
+		$GLOBALS['_hc_mock']['topic_author_id']  = 99;
+
+		$this->assertSame( $this->links, hcommons_topic_admin_links( $this->links ) );
+	}
+
+	public function test_group_mod_keeps_all_topic_links() {
+		$GLOBALS['_hc_mock']['current_user_id']  = 6;
+		$GLOBALS['_hc_mock']['current_group_id'] = 11;
+		$GLOBALS['_hc_mock']['group_mods']       = array( '6:11' );
+		$GLOBALS['_hc_mock']['topic_id']         = 201;
+		$GLOBALS['_hc_mock']['topic_author_id']  = 99;
+
+		$this->assertSame( $this->links, hcommons_topic_admin_links( $this->links ) );
+	}
+
+	public function test_plain_member_loses_edit_link_on_others_topic() {
+		$GLOBALS['_hc_mock']['current_user_id']  = 7;
+		$GLOBALS['_hc_mock']['current_group_id'] = 12;
+		$GLOBALS['_hc_mock']['topic_id']         = 202;
+		$GLOBALS['_hc_mock']['topic_author_id']  = 99;
+
+		$expected = $this->links;
+		unset( $expected['edit'] );
+
+		$this->assertSame( $expected, hcommons_topic_admin_links( $this->links ) );
+	}
+
+	public function test_author_keeps_edit_link_on_own_topic() {
+		$GLOBALS['_hc_mock']['current_user_id']  = 8;
+		$GLOBALS['_hc_mock']['current_group_id'] = 13;
+		$GLOBALS['_hc_mock']['topic_id']         = 203;
+		$GLOBALS['_hc_mock']['topic_author_id']  = 8;
+
+		$this->assertSame( $this->links, hcommons_topic_admin_links( $this->links ) );
+	}
+
+	public function test_group_admin_keeps_all_reply_links() {
+		$GLOBALS['_hc_mock']['current_user_id']  = 9;
+		$GLOBALS['_hc_mock']['current_group_id'] = 14;
+		$GLOBALS['_hc_mock']['group_admins']     = array( '9:14' );
+		$GLOBALS['_hc_mock']['reply_id']         = 300;
+		$GLOBALS['_hc_mock']['reply_author_id']  = 99;
+
+		$this->assertSame( $this->links, hcommons_reply_admin_links( $this->links ) );
+	}
+
+	public function test_plain_member_loses_edit_link_on_others_reply() {
+		$GLOBALS['_hc_mock']['current_user_id']  = 15;
+		$GLOBALS['_hc_mock']['current_group_id'] = 16;
+		$GLOBALS['_hc_mock']['reply_id']         = 301;
+		$GLOBALS['_hc_mock']['reply_author_id']  = 99;
+
+		$expected = $this->links;
+		unset( $expected['edit'] );
+
+		$this->assertSame( $expected, hcommons_reply_admin_links( $this->links ) );
+	}
+
+	public function test_author_keeps_edit_link_on_own_reply() {
+		$GLOBALS['_hc_mock']['current_user_id']  = 17;
+		$GLOBALS['_hc_mock']['current_group_id'] = 18;
+		$GLOBALS['_hc_mock']['reply_id']         = 302;
+		$GLOBALS['_hc_mock']['reply_author_id']  = 17;
+
+		$this->assertSame( $this->links, hcommons_reply_admin_links( $this->links ) );
+	}
+}

--- a/tests/unit/GroupForumModerationCapsTest.php
+++ b/tests/unit/GroupForumModerationCapsTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Tests for hc_custom_map_group_forum_meta_caps(): group admins and mods must
+ * regain bbPress moderation capabilities on their group's forum content.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class GroupForumModerationCapsTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['_hc_mock'] = array();
+	}
+
+	/**
+	 * Configure a topic (id 200) living in forum 100 attached to group 10.
+	 */
+	private function setUpGroupTopic( $topic_id = 200, $forum_id = 100, $group_id = 10 ) {
+		$topic            = new stdClass();
+		$topic->ID        = $topic_id;
+		$topic->post_type = 'topic';
+
+		$GLOBALS['_hc_mock']['posts']        = array( $topic_id => $topic );
+		$GLOBALS['_hc_mock']['topic_forums'] = array( $topic_id => $forum_id );
+		$GLOBALS['_hc_mock']['forum_groups'] = array( $forum_id => array( $group_id ) );
+	}
+
+	public function test_group_admin_can_edit_topic_in_group_forum() {
+		$this->setUpGroupTopic( 200, 100, 10 );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '5:10' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'edit_others_topics' ), 'edit_topic', 5, array( 200 ) );
+
+		$this->assertSame( array( 'participate' ), $caps );
+	}
+
+	public function test_group_mod_can_moderate_topic_in_group_forum() {
+		$this->setUpGroupTopic( 201, 101, 11 );
+		$GLOBALS['_hc_mock']['group_mods'] = array( '6:11' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'moderate' ), 'moderate', 6, array( 201 ) );
+
+		$this->assertSame( array( 'participate' ), $caps );
+	}
+
+	public function test_group_admin_can_delete_topic_in_group_forum() {
+		$this->setUpGroupTopic( 202, 102, 12 );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '7:12' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'delete_others_topics' ), 'delete_topic', 7, array( 202 ) );
+
+		$this->assertSame( array( 'participate' ), $caps );
+	}
+
+	public function test_group_mod_cannot_delete_topic_in_group_forum() {
+		$this->setUpGroupTopic( 203, 103, 13 );
+		$GLOBALS['_hc_mock']['group_mods'] = array( '8:13' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'delete_others_topics' ), 'delete_topic', 8, array( 203 ) );
+
+		$this->assertSame( array( 'delete_others_topics' ), $caps );
+	}
+
+	public function test_plain_member_does_not_get_moderation_caps() {
+		$this->setUpGroupTopic( 204, 104, 14 );
+		$GLOBALS['_hc_mock']['group_members'] = array( '9:14' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'edit_others_topics' ), 'edit_topic', 9, array( 204 ) );
+
+		$this->assertSame( array( 'edit_others_topics' ), $caps );
+	}
+
+	public function test_group_member_can_publish_topics() {
+		$this->setUpGroupTopic( 205, 105, 15 );
+		$GLOBALS['_hc_mock']['group_members'] = array( '20:15' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'publish_topics' ), 'publish_topics', 20, array( 205 ) );
+
+		$this->assertSame( array( 'participate' ), $caps );
+	}
+
+	public function test_banned_member_is_denied_publishing() {
+		$this->setUpGroupTopic( 206, 106, 16 );
+		$GLOBALS['_hc_mock']['group_members'] = array( '21:16' );
+		$GLOBALS['_hc_mock']['group_banned']  = array( '21:16' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'publish_topics' ), 'publish_topics', 21, array( 206 ) );
+
+		$this->assertSame( array( 'do_not_allow' ), $caps );
+	}
+
+	public function test_primitive_cap_without_object_uses_current_group_context() {
+		// No object id passed: e.g. current_user_can( 'edit_others_topics' ).
+		$GLOBALS['_hc_mock']['is_group']         = true;
+		$GLOBALS['_hc_mock']['current_group_id'] = 17;
+		$GLOBALS['_hc_mock']['group_admins']     = array( '22:17' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'edit_others_topics' ), 'edit_others_topics', 22, array() );
+
+		$this->assertSame( array( 'participate' ), $caps );
+	}
+
+	public function test_primitive_cap_without_object_outside_group_context_is_unchanged() {
+		$GLOBALS['_hc_mock']['is_group']     = false;
+		$GLOBALS['_hc_mock']['group_admins'] = array( '23:18' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'edit_others_topics' ), 'edit_others_topics', 23, array() );
+
+		$this->assertSame( array( 'edit_others_topics' ), $caps );
+	}
+
+	public function test_topic_in_non_group_forum_is_unchanged() {
+		$topic            = new stdClass();
+		$topic->ID        = 207;
+		$topic->post_type = 'topic';
+
+		$GLOBALS['_hc_mock']['posts']        = array( 207 => $topic );
+		$GLOBALS['_hc_mock']['topic_forums'] = array( 207 => 107 );
+		$GLOBALS['_hc_mock']['forum_groups'] = array( 107 => array() );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '24:19' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'edit_others_topics' ), 'edit_topic', 24, array( 207 ) );
+
+		$this->assertSame( array( 'edit_others_topics' ), $caps );
+	}
+
+	public function test_unrelated_cap_is_unchanged() {
+		$this->setUpGroupTopic( 208, 108, 25 );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '26:25' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'spectate' ), 'spectate', 26, array( 208 ) );
+
+		$this->assertSame( array( 'spectate' ), $caps );
+	}
+
+	public function test_group_admin_can_edit_reply_in_group_forum() {
+		$reply            = new stdClass();
+		$reply->ID        = 300;
+		$reply->post_type = 'reply';
+
+		$GLOBALS['_hc_mock']['posts']        = array( 300 => $reply );
+		$GLOBALS['_hc_mock']['reply_forums'] = array( 300 => 109 );
+		$GLOBALS['_hc_mock']['forum_groups'] = array( 109 => array( 27 ) );
+		$GLOBALS['_hc_mock']['group_admins'] = array( '28:27' );
+
+		$caps = hc_custom_map_group_forum_meta_caps( array( 'edit_others_replies' ), 'edit_reply', 28, array( 300 ) );
+
+		$this->assertSame( array( 'participate' ), $caps );
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -310,7 +310,9 @@ if ( ! function_exists( 'groups_update_groupmeta' ) ) {
 
 if ( ! function_exists( 'bp_get_current_group_id' ) ) {
 	function bp_get_current_group_id() {
-		return $GLOBALS['_mock_current_group_id'] ?? 0;
+		// Shared across suites: falls back to the _hc_mock store used by the
+		// group-permissions loader when the direct mock is not set.
+		return (int) ( $GLOBALS['_mock_current_group_id'] ?? $GLOBALS['_hc_mock']['current_group_id'] ?? 0 );
 	}
 }
 
@@ -339,3 +341,4 @@ if ( ! function_exists( 'wp_remote_request' ) ) {
 }
 
 require_once __DIR__ . '/xprofile-html-fix-loader.php';
+require_once __DIR__ . '/group-permissions-loader.php';

--- a/tests/unit/group-permissions-loader.php
+++ b/tests/unit/group-permissions-loader.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Stubs for WP/BP/bbPress functions used by the group permissions code under
+ * test, then loads the real plugin files:
+ *   - plugins/hc-custom/includes/bbpress.php
+ *   - plugins/hc-custom/includes/bp-event-organiser.php
+ *
+ * All stubs are configurable per-test through $GLOBALS['_hc_mock'] so tests can
+ * exercise behaviour (return values) without any live WordPress environment.
+ */
+
+// ---------------------------------------------------------------------------
+// Generic WP plugin API stubs.
+// ---------------------------------------------------------------------------
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['_hc_registered_filters'][ $hook ][] = array(
+			'callback' => $callback,
+			'priority' => $priority,
+		);
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_action' ) ) {
+	function remove_action( $hook, $callback, $priority = 10 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( '_x' ) ) {
+	function _x( $text, $context, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( $value, '/' ) . '/';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock helper.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a value from the per-test mock configuration.
+ */
+function _hc_mock( $key, $default = null ) {
+	return isset( $GLOBALS['_hc_mock'][ $key ] ) ? $GLOBALS['_hc_mock'][ $key ] : $default;
+}
+
+// ---------------------------------------------------------------------------
+// WordPress core stubs.
+// ---------------------------------------------------------------------------
+
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $post_id = null ) {
+		$posts = _hc_mock( 'posts', array() );
+		return isset( $posts[ $post_id ] ) ? $posts[ $post_id ] : null;
+	}
+}
+
+if ( ! function_exists( 'is_super_admin' ) ) {
+	function is_super_admin( $user_id = false ) {
+		return (bool) _hc_mock( 'is_super_admin', false );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return (int) _hc_mock( 'current_user_id', 0 );
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $cap, ...$args ) {
+		$can = _hc_mock( 'user_can', array() );
+		return ! empty( $can[ $cap ] );
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuddyPress stubs.
+// ---------------------------------------------------------------------------
+
+if ( ! function_exists( 'bp_is_group' ) ) {
+	function bp_is_group() {
+		return (bool) _hc_mock( 'is_group', false );
+	}
+}
+
+if ( ! function_exists( 'bp_get_current_group_id' ) ) {
+	function bp_get_current_group_id() {
+		return (int) _hc_mock( 'current_group_id', 0 );
+	}
+}
+
+if ( ! function_exists( 'bp_loggedin_user_id' ) ) {
+	function bp_loggedin_user_id() {
+		return (int) _hc_mock( 'current_user_id', 0 );
+	}
+}
+
+if ( ! function_exists( 'groups_is_user_admin' ) ) {
+	function groups_is_user_admin( $user_id, $group_id ) {
+		return in_array( "$user_id:$group_id", _hc_mock( 'group_admins', array() ), true );
+	}
+}
+
+if ( ! function_exists( 'groups_is_user_mod' ) ) {
+	function groups_is_user_mod( $user_id, $group_id ) {
+		return in_array( "$user_id:$group_id", _hc_mock( 'group_mods', array() ), true );
+	}
+}
+
+if ( ! function_exists( 'groups_is_user_member' ) ) {
+	function groups_is_user_member( $user_id, $group_id ) {
+		return in_array( "$user_id:$group_id", _hc_mock( 'group_members', array() ), true );
+	}
+}
+
+if ( ! function_exists( 'groups_is_user_banned' ) ) {
+	function groups_is_user_banned( $user_id, $group_id ) {
+		return in_array( "$user_id:$group_id", _hc_mock( 'group_banned', array() ), true );
+	}
+}
+
+if ( ! function_exists( 'groups_get_user_groups' ) ) {
+	function groups_get_user_groups( $user_id ) {
+		$user_groups = _hc_mock( 'user_groups', array() );
+		return array(
+			'groups' => isset( $user_groups[ $user_id ] ) ? $user_groups[ $user_id ] : array(),
+		);
+	}
+}
+
+if ( ! function_exists( 'groups_get_current_group' ) ) {
+	function groups_get_current_group() {
+		return _hc_mock( 'current_group', null );
+	}
+}
+
+if ( ! function_exists( 'bp_get_group_permalink' ) ) {
+	function bp_get_group_permalink( $group = null ) {
+		return _hc_mock( 'group_permalink', 'https://example.org/groups/test-group/' );
+	}
+}
+
+if ( ! function_exists( 'bp_core_new_subnav_item' ) ) {
+	function bp_core_new_subnav_item( $args, $component = null ) {
+		$GLOBALS['_hc_registered_subnav'][] = array(
+			'args'      => $args,
+			'component' => $component,
+		);
+		return true;
+	}
+}
+
+if ( ! class_exists( 'HC_Test_Group_Nav' ) ) {
+	class HC_Test_Group_Nav {
+		public function get_secondary( $args = array(), $sort = true ) {
+			return _hc_mock( 'existing_secondary_nav', array() );
+		}
+	}
+}
+
+if ( ! function_exists( 'buddypress' ) ) {
+	function buddypress() {
+		$bp                           = new stdClass();
+		$bp->groups                   = new stdClass();
+		$bp->groups->nav              = new HC_Test_Group_Nav();
+		$bp->groups->current_group    = _hc_mock( 'current_group', null );
+		return $bp;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// bbPress stubs.
+// ---------------------------------------------------------------------------
+
+if ( ! function_exists( 'bbp_get_forum_post_type' ) ) {
+	function bbp_get_forum_post_type() {
+		return 'forum';
+	}
+}
+
+if ( ! function_exists( 'bbp_get_topic_post_type' ) ) {
+	function bbp_get_topic_post_type() {
+		return 'topic';
+	}
+}
+
+if ( ! function_exists( 'bbp_get_reply_post_type' ) ) {
+	function bbp_get_reply_post_type() {
+		return 'reply';
+	}
+}
+
+if ( ! function_exists( 'bbp_get_topic_forum_id' ) ) {
+	function bbp_get_topic_forum_id( $topic_id ) {
+		$map = _hc_mock( 'topic_forums', array() );
+		return isset( $map[ $topic_id ] ) ? $map[ $topic_id ] : 0;
+	}
+}
+
+if ( ! function_exists( 'bbp_get_reply_forum_id' ) ) {
+	function bbp_get_reply_forum_id( $reply_id ) {
+		$map = _hc_mock( 'reply_forums', array() );
+		return isset( $map[ $reply_id ] ) ? $map[ $reply_id ] : 0;
+	}
+}
+
+if ( ! function_exists( 'bbp_get_forum_group_ids' ) ) {
+	function bbp_get_forum_group_ids( $forum_id ) {
+		$map = _hc_mock( 'forum_groups', array() );
+		return isset( $map[ $forum_id ] ) ? $map[ $forum_id ] : array();
+	}
+}
+
+if ( ! function_exists( 'bbp_get_topic_id' ) ) {
+	function bbp_get_topic_id( $topic_id = 0 ) {
+		return (int) _hc_mock( 'topic_id', 0 );
+	}
+}
+
+if ( ! function_exists( 'bbp_get_topic_author_id' ) ) {
+	function bbp_get_topic_author_id( $topic_id = 0 ) {
+		return (int) _hc_mock( 'topic_author_id', 0 );
+	}
+}
+
+if ( ! function_exists( 'bbp_get_reply_id' ) ) {
+	function bbp_get_reply_id( $reply_id = 0 ) {
+		return (int) _hc_mock( 'reply_id', 0 );
+	}
+}
+
+if ( ! function_exists( 'bbp_get_reply_author_id' ) ) {
+	function bbp_get_reply_author_id( $reply_id = 0 ) {
+		return (int) _hc_mock( 'reply_author_id', 0 );
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hc-custom / MLA stubs.
+// ---------------------------------------------------------------------------
+
+if ( ! function_exists( 'mla_is_group_committee' ) ) {
+	function mla_is_group_committee( $group_id ) {
+		return in_array( $group_id, _hc_mock( 'committees', array() ), true );
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BP Event Organiser stubs.
+// ---------------------------------------------------------------------------
+
+if ( ! function_exists( 'bpeo_get_event_groups' ) ) {
+	function bpeo_get_event_groups( $event_id ) {
+		$map = _hc_mock( 'event_groups', array() );
+		return isset( $map[ $event_id ] ) ? $map[ $event_id ] : array();
+	}
+}
+
+if ( ! function_exists( 'bpeo_get_group_minimum_member_role_for_connection' ) ) {
+	function bpeo_get_group_minimum_member_role_for_connection( $group_id ) {
+		$map = _hc_mock( 'group_min_role', array() );
+		return isset( $map[ $group_id ] ) ? $map[ $group_id ] : 'member';
+	}
+}
+
+if ( ! function_exists( 'bpeo_get_group_permalink' ) ) {
+	function bpeo_get_group_permalink( $group = null ) {
+		return _hc_mock( 'events_group_permalink', 'https://example.org/groups/test-group/events/' );
+	}
+}
+
+if ( ! function_exists( 'bpeo_get_events_slug' ) ) {
+	function bpeo_get_events_slug() {
+		return 'events';
+	}
+}
+
+if ( ! function_exists( 'bpeo_get_events_new_slug' ) ) {
+	function bpeo_get_events_new_slug() {
+		return 'new';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Load the real code under test.
+// ---------------------------------------------------------------------------
+
+require_once dirname( __DIR__, 2 ) . '/plugins/hc-custom/includes/bbpress.php';
+require_once dirname( __DIR__, 2 ) . '/plugins/hc-custom/includes/bp-event-organiser.php';


### PR DESCRIPTION
Fixes #105.

## Root cause

Both problems trace back to the BuddyPress 12+ rewrites parser: the request is now parsed on `bp_parse_query`, but group extensions are still constructed on `bp_init` (priority 11). Any group-context check made in an extension constructor (`bp_is_group()`, `bp_is_current_action()`) is therefore always false.

**Forums:** bbPress's `BBP_Forums_Group_Extension::setup_filters()` only attaches its `bbp_map_meta_caps` → `map_group_forum_meta_caps()` mapping when constructed inside a group forum request. That condition can no longer be met, so group admins/mods silently lost `edit_topic`, `edit_others_topics`, `moderate`, `delete_topic`, etc., and with them the Edit/Merge/Close/Stick/Trash/Spam admin links. (Ordinary posting still worked because the participant forum role carries publish caps directly, which is why only moderation broke.) On top of that, `hcommons_topic_admin_links()`/`hcommons_reply_admin_links()` in hc-custom stripped the Edit link from everyone except super admins and MLA committee admins.

**Events:** BP Event Organiser's `BP_Event_Organiser_Group_Extension` registers the events subnav (Calendar / Upcoming / Manage / New Event) from its constructor, which bails on `! bp_is_group()` — so the whole subnav, including the New Event button, disappeared for all users (visible as the empty subnav bar in the issue screenshots). Independently, the group event capability filter carried an unimplemented `@todo group admins / mods permissions` for `edit_event`, so group admins could never edit or delete events they didn't author.

## Changes (all in `plugins/hc-custom`)

- `includes/bbpress.php`
  - New `hc_custom_map_group_forum_meta_caps()` on `bbp_map_meta_caps` reinstating the stock bbPress group-forum mapping (members publish, mods moderate/edit, admins also delete), resolving group context from the topic/reply/forum being checked with a current-group fallback for primitive checks.
  - `hcommons_topic_admin_links()`/`hcommons_reply_admin_links()` now keep the full link set for group admins and mods of the current group, not just committee admins.
- `includes/bp-event-organiser.php`
  - New `hc_custom_bpeo_register_group_events_subnav()` on `bp_actions` re-registering the events subnav once group context exists (skips if already registered, e.g. fixed upstream).
  - `hc_custom_bpeo_group_event_meta_cap()` now grants `edit_event`/`delete_event` to admins of any group the event is connected to (mods get `edit_event`), and no longer relies on an accidental fall-through for the read cases.

## Tests

39 new self-contained unit tests (`tests/unit/GroupForumModerationCapsTest.php`, `ForumAdminLinksTest.php`, `BpeoGroupEventCapsTest.php`, `BpeoGroupEventsSubnavTest.php`) with a shared stub loader that exercises the real plugin files. Full suite: 65 tests, 102 assertions, all passing.