### PR TITLE
fix(hc-custom): restore group nav show/hide and landing page settings

### DIFF
--- a/plugins/hc-custom/includes/buddypress/bp-groups.php
+++ b/plugins/hc-custom/includes/buddypress/bp-groups.php
@@ -316,11 +316,28 @@ function hc_custom_get_options_nav( $parent_slug = '' ) {
 		$selected_item = bp_action_variable( 0 );
 	}
 
-	// If the nav is not defined by the parent component, look in the Members nav.
-	if ( ! isset( $bp->{$single_item_component}->nav ) ) {
-		$secondary_nav_items = $bp->members->nav->get_secondary( array( 'parent_slug' => $current_item ) );
-	} else {
-		$secondary_nav_items = $bp->{$single_item_component}->nav->get_secondary( array( 'parent_slug' => $current_item ) );
+	$secondary_nav_items = array();
+
+	// In a group, prefer the nav snapshot taken before hidden items were
+	// removed from the live nav: hidden items must stay listed here so they
+	// can be toggled back on.
+	if ( bp_is_group() ) {
+		$snapshot = groups_get_groupmeta( $group_id, 'group_nav_snapshot' );
+
+		if ( is_array( $snapshot ) && ! empty( $snapshot ) ) {
+			foreach ( $snapshot as $item ) {
+				$secondary_nav_items[] = (object) $item;
+			}
+		}
+	}
+
+	if ( empty( $secondary_nav_items ) ) {
+		// If the nav is not defined by the parent component, look in the Members nav.
+		if ( ! isset( $bp->{$single_item_component}->nav ) ) {
+			$secondary_nav_items = $bp->members->nav->get_secondary( array( 'parent_slug' => $current_item ) );
+		} else {
+			$secondary_nav_items = $bp->{$single_item_component}->nav->get_secondary( array( 'parent_slug' => $current_item ) );
+		}
 	}
 
 	if ( ! $secondary_nav_items ) {
@@ -409,17 +426,20 @@ function hc_custom_remove_group_manager_subnav_tabs() {
 
 	$group_id = bp_get_current_group_id();
 
-	// Group admins will see all tabs.
-	if ( ! $group_id || groups_is_user_admin( get_current_user_id(), $group_id ) ) {
+	if ( ! $group_id || ! isset( $bp->groups->nav ) || ! is_object( $bp->groups->nav ) ) {
 		return;
 	}
 
 	$parent_nav_slug     = bp_get_current_group_slug();
 	$secondary_nav_items = $bp->groups->nav->get_secondary( array( 'parent_slug' => $parent_nav_slug ) );
 
-	$selected_item = null;
+	if ( empty( $secondary_nav_items ) ) {
+		return;
+	}
 
-	// Remove the nav items. Not stored, just unsets it.
+	// Remove the nav items. Not stored, just unsets it. Hidden tabs are
+	// hidden for group admins too; they manage them from the settings
+	// screen, which lists items from the nav snapshot taken earlier.
 	foreach ( $secondary_nav_items as $subnav_item ) {
 		if ( 'hide' === groups_get_groupmeta( $group_id, $subnav_item->slug ) ) {
 
@@ -431,72 +451,154 @@ add_action( 'bp_actions', 'hc_custom_remove_group_manager_subnav_tabs' );
 
 
 /**
+ * Persist a snapshot of the group's secondary nav while it is available.
+ *
+ * Since BP 12 the current group is only resolved while a real group page
+ * request is parsed, so admin-ajax handlers never see the group nav. The
+ * snapshot is captured on every group page load (before hidden items are
+ * removed on bp_actions:10) and lets the landing page dropdown and the nav
+ * settings table work from groupmeta instead of the live nav.
+ */
+function hc_custom_snapshot_group_nav() {
+	global $bp;
+
+	if ( ! bp_is_group() ) {
+		return;
+	}
+
+	$group_id = bp_get_current_group_id();
+
+	if ( ! $group_id || ! isset( $bp->groups->nav ) || ! is_object( $bp->groups->nav ) ) {
+		return;
+	}
+
+	$secondary_nav_items = $bp->groups->nav->get_secondary( array( 'parent_slug' => bp_get_current_group_slug() ) );
+
+	if ( empty( $secondary_nav_items ) ) {
+		return;
+	}
+
+	$snapshot = array();
+
+	foreach ( $secondary_nav_items as $subnav_item ) {
+		$snapshot[] = array(
+			'slug'            => $subnav_item->slug,
+			'name'            => $subnav_item->name,
+			'link'            => isset( $subnav_item->link ) ? $subnav_item->link : '',
+			'screen_function' => isset( $subnav_item->screen_function ) && is_string( $subnav_item->screen_function ) ? $subnav_item->screen_function : '',
+		);
+	}
+
+	// Refresh the stored copy only when the nav has actually changed.
+	if ( $snapshot !== groups_get_groupmeta( $group_id, 'group_nav_snapshot' ) ) {
+		groups_update_groupmeta( $group_id, 'group_nav_snapshot', $snapshot );
+	}
+}
+add_action( 'bp_actions', 'hc_custom_snapshot_group_nav', 5 );
+
+/**
+ * Get the group's secondary nav items as plain arrays.
+ *
+ * Prefers the live nav when it is registered (a real group page request) and
+ * falls back to the snapshot persisted by hc_custom_snapshot_group_nav()
+ * otherwise (e.g. admin-ajax requests, where BP never sets the nav up).
+ *
+ * @param int    $group_id   The group id.
+ * @param string $group_slug The group slug.
+ * @return array[] List of items with slug, name, link and screen_function keys.
+ */
+function hc_custom_get_group_nav_items( $group_id, $group_slug ) {
+	global $bp;
+
+	if ( ! empty( $group_slug ) && isset( $bp->groups->nav ) && is_object( $bp->groups->nav ) ) {
+		$secondary_nav_items = $bp->groups->nav->get_secondary( array( 'parent_slug' => $group_slug ) );
+
+		if ( ! empty( $secondary_nav_items ) ) {
+			$items = array();
+
+			foreach ( $secondary_nav_items as $subnav_item ) {
+				$items[] = array(
+					'slug'            => $subnav_item->slug,
+					'name'            => $subnav_item->name,
+					'link'            => isset( $subnav_item->link ) ? $subnav_item->link : '',
+					'screen_function' => isset( $subnav_item->screen_function ) && is_string( $subnav_item->screen_function ) ? $subnav_item->screen_function : '',
+				);
+			}
+
+			return $items;
+		}
+	}
+
+	$snapshot = groups_get_groupmeta( $group_id, 'group_nav_snapshot' );
+
+	if ( is_array( $snapshot ) ) {
+		return array_values( $snapshot );
+	}
+
+	return array();
+}
+
+/**
+ * Build the option list for the landing page dropdown.
+ *
+ * @param int    $group_id   The group id.
+ * @param string $group_slug The group slug.
+ * @return string Concatenated option elements.
+ */
+function hc_custom_get_landing_page_options_html( $group_id, $group_slug ) {
+	$selected      = groups_get_groupmeta( $group_id, 'group_landing_page' );
+	$has_frontpage = ! empty( groups_get_groupmeta( $group_id, 'group_has_frontpage' ) );
+
+	$html = '';
+
+	foreach ( hc_custom_get_group_nav_items( $group_id, $group_slug ) as $item ) {
+		$item = (array) $item;
+		$slug = isset( $item['slug'] ) ? $item['slug'] : '';
+
+		if ( '' === $slug || 'invite-anyone' === $slug ) {
+			continue;
+		}
+
+		if ( isset( $item['screen_function'] ) && 'groups_screen_group_admin' === $item['screen_function'] ) {
+			continue;
+		}
+
+		if ( 'hide' === groups_get_groupmeta( $group_id, $slug ) ) {
+			continue;
+		}
+
+		$name = preg_replace( '/\d/', '', isset( $item['name'] ) ? $item['name'] : '' );
+
+		if ( 'Home' === $name && ! $has_frontpage ) {
+			$name = 'Activity';
+		}
+
+		$html .= '<option value="' . esc_attr( $slug ) . '"' . selected( $slug, $selected, false ) . '>' . $name . '</option>';
+	}
+
+	return $html;
+}
+
+/**
  * Allow group admin to change the default landing page.
  */
 function hc_custom_choose_landing_page() {
-	global $bp;
 
-	$group_id = ! empty( $_POST['group_id'] ) && isset( $_POST['group_id'] ) ? $_POST['group_id'] : '';
+	$group_id = ! empty( $_POST['group_id'] ) ? $_POST['group_id'] : '';
 
 	if ( empty( $group_id ) ) {
 		die( '-1' );
 	}
 
-	$parent_nav_slug = ! empty( $_POST['group_slug'] ) && isset( $_POST['group_slug'] ) ? $_POST['group_slug'] : '';
+	$parent_nav_slug = ! empty( $_POST['group_slug'] ) ? $_POST['group_slug'] : '';
 
-	$selected            = groups_get_groupmeta( $group_id, 'group_landing_page' );
-	$secondary_nav_items = $bp->groups->nav->get_secondary( array( 'parent_slug' => $parent_nav_slug ) );
-	
-	$has_frontpage = ! empty( groups_get_groupmeta( $group_id, 'group_has_frontpage' ) ) ? groups_get_groupmeta( $group_id, 'group_has_frontpage' )  : false;
-	
-	$html = '';
-
-	if ( isset( $_POST['menu_option_value'] ) && ! empty( $_POST['menu_option_value'] ) ) {
-
-		if ( isset( $_POST['menu_option_slug'] ) && ! empty( $_POST['menu_option_slug'] ) ) {
-			$menu_item = $_POST['menu_option_slug'];
-			$value     = $_POST['menu_option_value'];
-
-			groups_update_groupmeta( $group_id, $menu_item, $value );
-		}
+	// A show/hide toggle can be posted along with the refresh request; store
+	// it before building the options so the dropdown reflects it immediately.
+	if ( ! empty( $_POST['menu_option_value'] ) && ! empty( $_POST['menu_option_slug'] ) ) {
+		groups_update_groupmeta( $group_id, $_POST['menu_option_slug'], $_POST['menu_option_value'] );
 	}
 
-	foreach ( $secondary_nav_items as $subnav_item ) {
-
-		$name = preg_replace( '/\d/', '', $subnav_item->name );
-
-		if ( 'Home' === $name ) {
-			if( !$has_frontpage ) {
-			    $name = 'Activity';
-			}
-		}
-
-		if ( 'hide' === groups_get_groupmeta( $group_id, $subnav_item->slug ) ) {
-			continue;
-		}
-
-		if ( 'invite-anyone' == $subnav_item->slug ) {
-			continue;
-		}
-
-		if ( 'groups_screen_group_admin' === $subnav_item->screen_function ) {
-			continue;
-		}
-
-		if ( isset( $_POST['menu_option_value'] ) && ! empty( $_POST['menu_option_value'] ) ) {
-
-			if ( isset( $_POST['menu_option_slug'] ) && ! empty( $_POST['menu_option_slug'] ) ) {
-
-				if ( $subnav_item->slug === $_POST['menu_option_slug'] && 'hide' === $_POST['menu_option_value'] ) {
-					continue;
-				}
-			}
-		}
-
-		$html .= '<option value="' . esc_attr( $subnav_item->slug ) . '"' . selected( $subnav_item->slug, $selected ) . '>' . $name . '</option>';
-
-	}
-	echo $html;
+	echo hc_custom_get_landing_page_options_html( $group_id, $parent_nav_slug );
 
 	die();
 
@@ -507,33 +609,38 @@ add_action( 'wp_ajax_generate_menu_options_dropdown', 'hc_custom_choose_landing_
 
 
 /**
- * Grey out group navs if they are hidden.
+ * Suppress hidden group nav items when they reach the renderer.
+ *
+ * Hidden items are normally removed from the nav on bp_actions, but if one
+ * still makes it as far as bp_get_options_nav() this stops its label from
+ * being printed as unstyled text in the nav.
  *
  * @param string $string Unchanged filter string.
- * @param array  $subnav_item Array of nav item.
+ * @param object $subnav_item Nav item object.
  * @param string $selected_item Currently selected nav item.
  */
 function hc_custom_modify_nav( $string, $subnav_item, $selected_item ) {
-	global $bp;
 
-	// Site admins will see all tabs.
 	if ( ! bp_is_group() ) {
 		return $string;
 	}
 
 	$group_id = bp_get_current_group_id();
 
-	// Group admins will see all tabs.
-	if ( ! $group_id && ( ! groups_is_user_admin( get_current_user_id(), $group_id ) || ! is_super_admin() ) ) {
-
+	if ( ! $group_id ) {
 		return $string;
 	}
 
-	if ( 'hide' === groups_get_groupmeta( $group_id, $subnav_item->slug ) ) {
-		$string = '<li class="disabled-group-nav" id="' . esc_attr( $subnav_item->css_id . '-groups-li' ) . '" ' . $selected_item . '><span class="disabled-nav"> ' . $subnav_item->name . '</span></li>';
+	if ( 'hide' !== groups_get_groupmeta( $group_id, $subnav_item->slug ) ) {
+		return $string;
 	}
 
-	return $string;
+	// Site admins still see hidden tabs.
+	if ( is_super_admin() ) {
+		return $string;
+	}
+
+	return '';
 }
 
 /**

--- a/tests/unit/GroupNavSettingsTest.php
+++ b/tests/unit/GroupNavSettingsTest.php
@@ -1,0 +1,391 @@
+<?php
+/**
+ * Behavioural tests for the group nav show/hide settings (hc-custom).
+ *
+ * Covers the two regressions from the group Manage > Settings screen:
+ *  - the "Select Default Landing Page for Group" dropdown must be buildable
+ *    from a persisted nav snapshot, because on BP 12+ the group nav is never
+ *    registered during admin-ajax requests;
+ *  - menu items set to "hide" must not render in the group nav (no orphaned
+ *    labels), for regular members and group admins alike, while remaining
+ *    listed on the settings screen so they can be toggled back on.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/group-nav-settings-loader.php';
+
+class GroupNavSettingsTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['_hc_mock']        = array();
+		$GLOBALS['_mock_group_meta'] = array();
+		unset( $GLOBALS['_mock_current_group_id'] );
+		$GLOBALS['bp'] = $this->makeBp( array() );
+	}
+
+	private function makeBp( array $items ) {
+		$bp              = new stdClass();
+		$bp->groups      = new stdClass();
+		$bp->groups->nav = new HC_Test_BP_Options_Nav( $items );
+
+		return $bp;
+	}
+
+	private function defaultNavItems() {
+		return array(
+			array(
+				'slug'            => 'home',
+				'name'            => 'Home',
+				'link'            => 'https://example.org/groups/test-group/home/',
+				'screen_function' => 'groups_screen_group_home',
+			),
+			array(
+				'slug'            => 'forum',
+				'name'            => 'Forum',
+				'link'            => 'https://example.org/groups/test-group/forum/',
+				'screen_function' => 'groups_screen_group_forum',
+			),
+			array(
+				'slug'            => 'events',
+				'name'            => 'Events',
+				'link'            => 'https://example.org/groups/test-group/events/',
+				'screen_function' => 'bpeo_screen_group_events',
+			),
+			array(
+				'slug'            => 'invite-anyone',
+				'name'            => 'Send Invites',
+				'link'            => 'https://example.org/groups/test-group/invite-anyone/',
+				'screen_function' => 'invite_anyone_catch_group_invites',
+			),
+			array(
+				'slug'            => 'admin',
+				'name'            => 'Manage',
+				'link'            => 'https://example.org/groups/test-group/admin/',
+				'screen_function' => 'groups_screen_group_admin',
+			),
+		);
+	}
+
+	/**
+	 * Put the mocks into "real group page request" state: BP has resolved the
+	 * group and registered its secondary nav.
+	 */
+	private function enterGroupPage( $group_id, $slug, array $items ) {
+		$GLOBALS['_hc_mock']['is_group']           = true;
+		$GLOBALS['_hc_mock']['current_group_id']   = $group_id;
+		$GLOBALS['_hc_mock']['current_group_slug'] = $slug;
+		$GLOBALS['_hc_mock']['current_item']       = $slug;
+		$GLOBALS['_hc_mock']['current_component']  = 'groups';
+		$GLOBALS['bp']                             = $this->makeBp( $items );
+	}
+
+	/**
+	 * Put the mocks into "admin-ajax request" state: no group context, no
+	 * group nav registered.
+	 */
+	private function enterAdminAjax() {
+		$GLOBALS['_hc_mock']['is_group'] = false;
+		unset(
+			$GLOBALS['_hc_mock']['current_group_id'],
+			$GLOBALS['_hc_mock']['current_group_slug'],
+			$GLOBALS['_hc_mock']['current_item']
+		);
+		$GLOBALS['bp'] = $this->makeBp( array() );
+	}
+
+	private function navSlugs() {
+		$items = $GLOBALS['bp']->groups->nav->get_secondary( array( 'parent_slug' => 'test-group' ) );
+
+		if ( empty( $items ) ) {
+			return array();
+		}
+
+		return array_map(
+			function ( $item ) {
+				return $item->slug;
+			},
+			$items
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Bug (a): landing page dropdown empty in admin-ajax.
+	// -----------------------------------------------------------------------
+
+	public function test_dropdown_options_available_in_admin_ajax_after_group_page_snapshot() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+
+		$this->enterAdminAjax();
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertStringContainsString( 'value="home"', $html );
+		$this->assertStringContainsString( 'value="forum"', $html );
+		$this->assertStringContainsString( 'value="events"', $html );
+	}
+
+	public function test_dropdown_excludes_admin_screens_and_invite_anyone() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+
+		$this->enterAdminAjax();
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertStringNotContainsString( 'value="admin"', $html );
+		$this->assertStringNotContainsString( 'value="invite-anyone"', $html );
+	}
+
+	public function test_dropdown_excludes_items_hidden_via_group_settings() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+
+		$this->enterAdminAjax();
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertStringNotContainsString( 'value="events"', $html );
+		$this->assertStringContainsString( 'value="forum"', $html );
+	}
+
+	public function test_dropdown_renames_home_to_activity_when_group_has_no_frontpage() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+
+		$this->enterAdminAjax();
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertStringContainsString( '>Activity<', $html );
+		$this->assertStringNotContainsString( '>Home<', $html );
+	}
+
+	public function test_dropdown_keeps_home_label_when_group_has_frontpage() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+		$GLOBALS['_mock_group_meta'][7]['group_has_frontpage'] = '1';
+
+		$this->enterAdminAjax();
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertStringContainsString( '>Home<', $html );
+	}
+
+	public function test_dropdown_marks_saved_landing_page_as_selected() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+		$GLOBALS['_mock_group_meta'][7]['group_landing_page'] = 'forum';
+
+		$this->enterAdminAjax();
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertMatchesRegularExpression( '/value="forum"[^>]*selected/', $html );
+		$this->assertDoesNotMatchRegularExpression( '/value="events"[^>]*selected/', $html );
+	}
+
+	public function test_dropdown_uses_live_nav_when_group_nav_is_registered() {
+		// No snapshot has ever been taken, but the nav is available (a real
+		// group page request): options must still be produced.
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertStringContainsString( 'value="forum"', $html );
+		$this->assertStringContainsString( 'value="events"', $html );
+	}
+
+	public function test_dropdown_is_empty_only_when_group_never_visited() {
+		$this->enterAdminAjax();
+
+		$this->assertSame( '', hc_custom_get_landing_page_options_html( 99, 'never-visited' ) );
+	}
+
+	public function test_snapshot_refreshes_when_group_nav_changes() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+
+		// A new tab (Docs) appears on a later page load.
+		$items   = $this->defaultNavItems();
+		$items[] = array(
+			'slug'            => 'docs',
+			'name'            => 'Docs',
+			'link'            => 'https://example.org/groups/test-group/docs/',
+			'screen_function' => 'bp_docs_screen',
+		);
+		$this->enterGroupPage( 7, 'test-group', $items );
+		hc_custom_snapshot_group_nav();
+
+		$this->enterAdminAjax();
+		$html = hc_custom_get_landing_page_options_html( 7, 'test-group' );
+
+		$this->assertStringContainsString( 'value="docs"', $html );
+	}
+
+	// -----------------------------------------------------------------------
+	// Bug (b): hidden menu items must not render in the group nav.
+	// -----------------------------------------------------------------------
+
+	public function test_modify_nav_outputs_nothing_for_hidden_items() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+
+		$item = (object) array(
+			'slug'   => 'events',
+			'name'   => 'Events',
+			'css_id' => 'nav-events',
+		);
+
+		$rendered = '<li id="nav-events-groups-li"><a href="https://example.org/groups/test-group/events/">Events</a></li>';
+
+		$this->assertSame( '', hc_custom_modify_nav( $rendered, $item, '' ) );
+	}
+
+	public function test_modify_nav_outputs_nothing_for_hidden_items_when_viewer_is_group_admin() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+		$GLOBALS['_hc_mock']['current_user_id']   = 5;
+		$GLOBALS['_hc_mock']['group_admins']      = array( '5:7' );
+
+		$item = (object) array(
+			'slug'   => 'events',
+			'name'   => 'Events',
+			'css_id' => 'nav-events',
+		);
+
+		$rendered = '<li id="nav-events-groups-li"><a href="#">Events</a></li>';
+
+		$this->assertSame( '', hc_custom_modify_nav( $rendered, $item, '' ) );
+	}
+
+	public function test_modify_nav_leaves_visible_items_untouched() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+
+		$item = (object) array(
+			'slug'   => 'forum',
+			'name'   => 'Forum',
+			'css_id' => 'nav-forum',
+		);
+
+		$rendered = '<li id="nav-forum-groups-li"><a href="#">Forum</a></li>';
+
+		$this->assertSame( $rendered, hc_custom_modify_nav( $rendered, $item, '' ) );
+	}
+
+	public function test_modify_nav_keeps_hidden_items_for_super_admins() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+		$GLOBALS['_hc_mock']['is_super_admin']    = true;
+
+		$item = (object) array(
+			'slug'   => 'events',
+			'name'   => 'Events',
+			'css_id' => 'nav-events',
+		);
+
+		$rendered = '<li id="nav-events-groups-li"><a href="#">Events</a></li>';
+
+		$this->assertSame( $rendered, hc_custom_modify_nav( $rendered, $item, '' ) );
+	}
+
+	public function test_modify_nav_ignores_non_group_context() {
+		$GLOBALS['_hc_mock']['is_group'] = false;
+
+		$item = (object) array(
+			'slug'   => 'events',
+			'name'   => 'Events',
+			'css_id' => 'nav-events',
+		);
+
+		$rendered = '<li id="nav-events-groups-li"><a href="#">Events</a></li>';
+
+		$this->assertSame( $rendered, hc_custom_modify_nav( $rendered, $item, '' ) );
+	}
+
+	public function test_hidden_subnav_items_removed_for_regular_members() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+		$GLOBALS['_hc_mock']['current_user_id']   = 9;
+
+		hc_custom_remove_group_manager_subnav_tabs();
+
+		$this->assertNotContains( 'events', $this->navSlugs() );
+		$this->assertContains( 'forum', $this->navSlugs() );
+	}
+
+	public function test_hidden_subnav_items_removed_for_group_admins() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+		$GLOBALS['_hc_mock']['current_user_id']   = 5;
+		$GLOBALS['_hc_mock']['group_admins']      = array( '5:7' );
+
+		hc_custom_remove_group_manager_subnav_tabs();
+
+		$this->assertNotContains( 'events', $this->navSlugs() );
+		$this->assertContains( 'forum', $this->navSlugs() );
+	}
+
+	public function test_hidden_subnav_items_kept_for_super_admins() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+		$GLOBALS['_hc_mock']['is_super_admin']    = true;
+
+		hc_custom_remove_group_manager_subnav_tabs();
+
+		$this->assertContains( 'events', $this->navSlugs() );
+	}
+
+	// -----------------------------------------------------------------------
+	// Settings screen: hidden items must stay listed so they can be re-shown.
+	// -----------------------------------------------------------------------
+
+	public function test_settings_table_still_lists_items_removed_from_live_nav() {
+		// Snapshot is taken early in the request, while the nav is complete.
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+
+		// By render time the hidden item has been removed from the live nav.
+		$items = array_values(
+			array_filter(
+				$this->defaultNavItems(),
+				function ( $item ) {
+					return 'events' !== $item['slug'];
+				}
+			)
+		);
+		$GLOBALS['bp'] = $this->makeBp( $items );
+
+		ob_start();
+		hc_custom_get_options_nav();
+		$table = ob_get_clean();
+
+		$this->assertStringContainsString( 'group-nav-settings[events]', $table );
+		$this->assertStringContainsString( 'group-nav-settings[forum]', $table );
+	}
+
+	public function test_settings_table_never_offers_admin_screens() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+
+		ob_start();
+		hc_custom_get_options_nav();
+		$table = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'group-nav-settings[admin]', $table );
+		$this->assertStringNotContainsString( 'group-nav-settings[invite-anyone]', $table );
+	}
+
+	public function test_settings_table_checks_hide_radio_for_hidden_items() {
+		$this->enterGroupPage( 7, 'test-group', $this->defaultNavItems() );
+		hc_custom_snapshot_group_nav();
+		$GLOBALS['_mock_group_meta'][7]['events'] = 'hide';
+
+		ob_start();
+		hc_custom_get_options_nav();
+		$table = ob_get_clean();
+
+		$this->assertMatchesRegularExpression(
+			'/name="group-nav-settings\[events\]" value="hide"\s+checked="checked"/s',
+			$table
+		);
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -348,6 +348,28 @@ if ( ! function_exists( 'wp_remote_post' ) ) {
 	}
 }
 
+if ( ! function_exists( '_e' ) ) {
+	function _e( $text, $domain = 'default' ) {
+		echo $text;
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $url ) {
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'selected' ) ) {
+	function selected( $selected, $current = true, $display = true ) {
+		$result = ( (string) $selected === (string) $current ) ? " selected='selected'" : '';
+		if ( $display ) {
+			echo $result;
+		}
+		return $result;
+	}
+}
+
 if ( ! function_exists( 'wp_remote_request' ) ) {
 	function wp_remote_request( $url, $args = [] ) {
 		if ( isset( $GLOBALS['_mock_wp_remote_request_callback'] ) ) {

--- a/tests/unit/group-nav-settings-loader.php
+++ b/tests/unit/group-nav-settings-loader.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Loads plugins/hc-custom/includes/buddypress/bp-groups.php for unit testing.
+ *
+ * Provides guarded stubs for the WP/BuddyPress functions the group nav
+ * settings code calls at runtime. Behaviour is configured per-test through
+ * $GLOBALS['_hc_mock'] (see group-permissions-loader.php, loaded from the
+ * bootstrap, which supplies _hc_mock(), bp_is_group(), is_super_admin(),
+ * get_current_user_id() and groups_is_user_admin()) and through the
+ * $GLOBALS['_mock_group_meta'] store from the bootstrap.
+ *
+ * The BuddyPress nav object is faked with HC_Test_BP_Options_Nav: tests
+ * assign an instance to $GLOBALS['bp']->groups->nav and the
+ * bp_core_remove_subnav_item() stub mutates it, so removal behaviour can be
+ * asserted on resulting nav state rather than on recorded calls.
+ */
+
+if ( ! class_exists( 'HC_Test_BP_Options_Nav' ) ) {
+	class HC_Test_BP_Options_Nav {
+		/** @var object[] */
+		public $items = array();
+
+		public function __construct( array $items = array() ) {
+			foreach ( $items as $item ) {
+				$this->items[] = (object) $item;
+			}
+		}
+
+		public function get_secondary( $args = array(), $sort = true ) {
+			if ( empty( $this->items ) ) {
+				// BP_Core_Nav::get_secondary() returns false when nothing matches.
+				return false;
+			}
+
+			return $this->items;
+		}
+	}
+}
+
+if ( ! function_exists( 'bp_get_current_group_slug' ) ) {
+	function bp_get_current_group_slug() {
+		return (string) _hc_mock( 'current_group_slug', '' );
+	}
+}
+
+if ( ! function_exists( 'bp_get_group_id' ) ) {
+	function bp_get_group_id() {
+		return (int) _hc_mock( 'current_group_id', 0 );
+	}
+}
+
+if ( ! function_exists( 'bp_current_item' ) ) {
+	function bp_current_item() {
+		return _hc_mock( 'current_item', false );
+	}
+}
+
+if ( ! function_exists( 'bp_current_component' ) ) {
+	function bp_current_component() {
+		return _hc_mock( 'current_component', 'groups' );
+	}
+}
+
+if ( ! function_exists( 'bp_action_variable' ) ) {
+	function bp_action_variable( $position = 0 ) {
+		$vars = _hc_mock( 'action_variables', array() );
+		return isset( $vars[ $position ] ) ? $vars[ $position ] : false;
+	}
+}
+
+if ( ! function_exists( 'bp_core_remove_subnav_item' ) ) {
+	function bp_core_remove_subnav_item( $parent_slug, $slug, $component = 'members' ) {
+		$nav = isset( $GLOBALS['bp']->groups->nav ) ? $GLOBALS['bp']->groups->nav : null;
+
+		if ( $nav instanceof HC_Test_BP_Options_Nav ) {
+			$nav->items = array_values(
+				array_filter(
+					$nav->items,
+					function ( $item ) use ( $slug ) {
+						return $item->slug !== $slug;
+					}
+				)
+			);
+		}
+
+		return true;
+	}
+}
+
+require_once dirname( __DIR__, 2 ) . '/plugins/hc-custom/includes/buddypress/bp-groups.php';


### PR DESCRIPTION
Fixes #114.

Two regressions on the group Manage > Settings screen, both rooted in BP 12+ no longer resolving the current group outside a real group page request.

**Empty landing page dropdown.** The `generate_menu_options_dropdown` admin-ajax handler read `$bp->groups->nav->get_secondary()`, but in admin-ajax the group nav is never registered on BP 12+, so it always produced zero options. The plugin now persists a snapshot of the group's secondary nav (slug, name, link, screen function) in groupmeta on every group page load (`bp_actions:5`), and the handler builds the options from that snapshot when the live nav is unavailable, with the same filtering as before (skips hidden items, invite-anyone, admin screens; renames Home to Activity when the group has no front page). The snapshot refreshes on each group page load, so it can't go stale, and it is always fresh by the time the settings screen fires the ajax request. No theme changes needed.

**Hidden tabs still rendering as a bare label.** `hc_custom_modify_nav()` was supposed to grey hidden tabs out, but a broken guard (`! $group_id && (...)`) meant every viewer got the tab swapped for an unstyled `<span>` — the misaligned "Events" text in the issue screenshot — and group admins were exempted from the `bp_actions` subnav removal entirely, so the tab was never actually removed for them. Now:

- hidden tabs are removed from the nav for group admins too (site admins still see all tabs);
- the render filter returns nothing for a hidden tab instead of the orphaned label, as a safety net if one survives to output;
- the settings table reads from the nav snapshot (taken before removal runs), so hidden tabs remain listed there and can be toggled back on.

Also fixes the handler's `selected()` call, which echoed the attribute into the ajax response instead of only concatenating it.

Tested with behavioural unit tests (`tests/unit/GroupNavSettingsTest.php`, 20 tests): snapshot round-trip into the ajax path, option filtering/selection, hidden-tab suppression per role, and the settings table still listing removed tabs. Full suite: 117 tests, 188 assertions, green.

A pre-existing note for a follow-up: the dropdown handler is registered on `wp_ajax_nopriv_` and writes groupmeta from POST without a nonce or capability check; that predates this change and is left untouched here.