### PR TITLE
fix(hc-custom): gate group event creation on the group connection setting

### DIFF
--- a/plugins/hc-custom/includes/bp-event-organiser.php
+++ b/plugins/hc-custom/includes/bp-event-organiser.php
@@ -82,6 +82,66 @@ function hc_custom_bpeo_filter_query_for_bp_group( $query ) {
 add_action( 'pre_get_posts', 'hc_custom_remove_bpeo_filter_query_for_bp_group' );
 
 /**
+ * Whether a user may connect (create) events for a group.
+ *
+ * Decided by the group's "minimum member role" setting (groupmeta
+ * 'bpeo_connect_member_role': 'member' [default] or 'admin_mod') and the
+ * user's role within the group.
+ *
+ * This deliberately does not rely on WP blog capabilities. The capability
+ * chain used to map 'connect_event_to_group' to the 'read' primitive, but on
+ * this multisite users frequently hold no role on the society site they are
+ * visiting, so 'read' is missing and the check failed for everyone — even
+ * group admins — regardless of the group setting.
+ *
+ * @param int $user_id  ID of the user.
+ * @param int $group_id ID of the group.
+ * @return bool
+ */
+function hc_custom_bpeo_user_can_connect_event_to_group( $user_id, $group_id ) {
+	$user_id  = (int) $user_id;
+	$group_id = (int) $group_id;
+
+	if ( ! $user_id || ! $group_id ) {
+		return false;
+	}
+
+	if ( is_super_admin( $user_id ) ) {
+		return true;
+	}
+
+	if ( groups_is_user_banned( $user_id, $group_id ) ) {
+		return false;
+	}
+
+	if ( function_exists( 'bpeo_get_group_minimum_member_role_for_connection' ) ) {
+		$setting = bpeo_get_group_minimum_member_role_for_connection( $group_id );
+	} else {
+		$setting = groups_get_groupmeta( $group_id, 'bpeo_connect_member_role', true );
+	}
+
+	$is_admin_or_mod = groups_is_user_admin( $user_id, $group_id ) || groups_is_user_mod( $user_id, $group_id );
+
+	if ( 'admin_mod' === $setting ) {
+		$can_connect = $is_admin_or_mod;
+	} else {
+		// Default 'member' setting: any (non-banned) group member.
+		$can_connect = $is_admin_or_mod || (bool) groups_is_user_member( $user_id, $group_id );
+	}
+
+	// Preserve the Humanities Commons new-member vetting, which previously
+	// applied to event connection through the 'read' primitive capability.
+	if ( $can_connect
+		&& $user_id === (int) get_current_user_id()
+		&& is_callable( array( 'Humanities_Commons', 'hcommons_vet_user' ) )
+		&& ! Humanities_Commons::hcommons_vet_user() ) {
+		$can_connect = false;
+	}
+
+	return $can_connect;
+}
+
+/**
  * Modify EO capabilities for group membership. Add capabilities for private events.
  *
  * @param array  $caps    Capability array.
@@ -152,18 +212,24 @@ function hc_custom_bpeo_group_event_meta_cap( $caps, $cap, $user_id, $args ) {
 
 			break;
 
-		case 'connect_event_to_group':
-			$group_id = $args[0];
-			$setting  = bpeo_get_group_minimum_member_role_for_connection( $group_id );
-
-			if ( 'admin_mod' === $setting ) {
-				$can_connect = groups_is_user_admin( $user_id, $group_id ) || groups_is_user_mod( $user_id, $group_id );
-			} else {
-				$can_connect = groups_is_user_member( $user_id, $group_id );
+		case 'publish_events':
+			// Publishing from a group's New Event screen: when the group's
+			// connection setting allows this user to create events there, do
+			// not additionally require blog-role primitives such as 'read',
+			// which users without a role on the society site do not have.
+			$current_group_id = function_exists( 'bp_get_current_group_id' ) ? bp_get_current_group_id() : 0;
+			if ( $current_group_id && hc_custom_bpeo_user_can_connect_event_to_group( $user_id, $current_group_id ) ) {
+				$caps = array( 'exist' );
 			}
 
-			if ( $can_connect ) {
-				$caps = array( 'read' );
+			break;
+
+		case 'connect_event_to_group':
+			if ( hc_custom_bpeo_user_can_connect_event_to_group( $user_id, $args[0] ) ) {
+				// 'exist' rather than 'read': users are not guaranteed a WP
+				// role (and thus 'read') on the society site, and the group
+				// setting is what governs this permission.
+				$caps = array( 'exist' );
 			}
 
 			break;
@@ -171,7 +237,9 @@ function hc_custom_bpeo_group_event_meta_cap( $caps, $cap, $user_id, $args ) {
 
 	return $caps;
 }
-add_filter( 'map_meta_cap', 'hc_custom_bpeo_group_event_meta_cap', 20, 5 );
+// Priority 30 so this runs after bp-event-organiser's own filter (priority 20)
+// and its 'read'-based mapping cannot override the result.
+add_filter( 'map_meta_cap', 'hc_custom_bpeo_group_event_meta_cap', 30, 4 );
 
 /**
  * Register the events subnav (Calendar / Upcoming / Manage / New Event) for the
@@ -191,6 +259,18 @@ function hc_custom_bpeo_register_group_events_subnav() {
 
 	$group = groups_get_current_group();
 	if ( empty( $group->slug ) ) {
+		return;
+	}
+
+	$user_id        = bp_loggedin_user_id();
+	$is_group_admin = (bool) groups_is_user_admin( $user_id, $group->id );
+
+	// Respect the group's "show or hide menu items" setting for the Events
+	// tab (see hc_custom_remove_group_manager_subnav_tabs()): when the tab is
+	// hidden, do not register its subnav either. Site admins and group admins
+	// always see all tabs, matching the removal logic.
+	if ( ! is_super_admin() && ! $is_group_admin
+		&& 'hide' === groups_get_groupmeta( $group->id, bpeo_get_events_slug() ) ) {
 		return;
 	}
 
@@ -239,14 +319,17 @@ function hc_custom_bpeo_register_group_events_subnav() {
 		array(
 			'name'            => __( 'Manage', 'bp-event-organiser' ),
 			'slug'            => 'manage',
-			'user_has_access' => (bool) groups_is_user_admin( bp_loggedin_user_id(), $group->id ),
+			'user_has_access' => $is_group_admin,
 			'position'        => 0,
 			'link'            => trailingslashit( bp_get_group_permalink( $group ) . 'admin/' . bpeo_get_events_slug() ),
 		),
 		$default_params
 	);
 
-	if ( current_user_can( 'connect_event_to_group', $group->id ) ) {
+	// Gate the New Event button on the group's connection setting directly
+	// rather than on current_user_can(), whose 'read' primitive mapping fails
+	// for users without a WP role on the society site.
+	if ( hc_custom_bpeo_user_can_connect_event_to_group( $user_id, $group->id ) ) {
 		$sub_nav[] = array_merge(
 			array(
 				'name'            => __( 'New Event', 'bp-event-organiser' ),

--- a/tests/unit/BpeoConnectEventPermissionTest.php
+++ b/tests/unit/BpeoConnectEventPermissionTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for hc_custom_bpeo_user_can_connect_event_to_group(): whether a user
+ * may connect (create) events for a group must be decided by the group's
+ * "minimum member role" setting (groupmeta 'bpeo_connect_member_role') and the
+ * user's role within the group — not by WP blog-role capabilities, which
+ * society-site users do not reliably have.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class BpeoConnectEventPermissionTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['_hc_mock']        = array();
+		$GLOBALS['_mock_group_meta'] = array();
+	}
+
+	public function test_member_can_connect_under_default_member_setting() {
+		$GLOBALS['_hc_mock']['group_members'] = array( '20:60' );
+
+		$this->assertTrue( hc_custom_bpeo_user_can_connect_event_to_group( 20, 60 ) );
+	}
+
+	public function test_non_member_cannot_connect() {
+		$this->assertFalse( hc_custom_bpeo_user_can_connect_event_to_group( 21, 60 ) );
+	}
+
+	public function test_group_admin_can_connect_under_member_setting() {
+		$GLOBALS['_hc_mock']['group_admins'] = array( '22:60' );
+
+		$this->assertTrue( hc_custom_bpeo_user_can_connect_event_to_group( 22, 60 ) );
+	}
+
+	public function test_member_cannot_connect_under_admin_mod_setting() {
+		$GLOBALS['_hc_mock']['group_members']  = array( '23:61' );
+		$GLOBALS['_hc_mock']['group_min_role'] = array( 61 => 'admin_mod' );
+
+		$this->assertFalse( hc_custom_bpeo_user_can_connect_event_to_group( 23, 61 ) );
+	}
+
+	public function test_group_admin_can_connect_under_admin_mod_setting() {
+		$GLOBALS['_hc_mock']['group_admins']   = array( '24:61' );
+		$GLOBALS['_hc_mock']['group_min_role'] = array( 61 => 'admin_mod' );
+
+		$this->assertTrue( hc_custom_bpeo_user_can_connect_event_to_group( 24, 61 ) );
+	}
+
+	public function test_group_mod_can_connect_under_admin_mod_setting() {
+		$GLOBALS['_hc_mock']['group_mods']     = array( '25:61' );
+		$GLOBALS['_hc_mock']['group_min_role'] = array( 61 => 'admin_mod' );
+
+		$this->assertTrue( hc_custom_bpeo_user_can_connect_event_to_group( 25, 61 ) );
+	}
+
+	public function test_banned_member_cannot_connect() {
+		$GLOBALS['_hc_mock']['group_members'] = array( '26:60' );
+		$GLOBALS['_hc_mock']['group_banned']  = array( '26:60' );
+
+		$this->assertFalse( hc_custom_bpeo_user_can_connect_event_to_group( 26, 60 ) );
+	}
+
+	public function test_super_admin_can_connect() {
+		$GLOBALS['_hc_mock']['is_super_admin'] = true;
+
+		$this->assertTrue( hc_custom_bpeo_user_can_connect_event_to_group( 27, 60 ) );
+	}
+
+	public function test_unvetted_current_user_cannot_connect() {
+		$GLOBALS['_hc_mock']['group_members']   = array( '28:60' );
+		$GLOBALS['_hc_mock']['current_user_id'] = 28;
+		$GLOBALS['_hc_mock']['vetted_user']     = false;
+
+		$this->assertFalse( hc_custom_bpeo_user_can_connect_event_to_group( 28, 60 ) );
+	}
+
+	public function test_missing_user_or_group_is_denied() {
+		$GLOBALS['_hc_mock']['group_members'] = array( '20:60' );
+
+		$this->assertFalse( hc_custom_bpeo_user_can_connect_event_to_group( 0, 60 ) );
+		$this->assertFalse( hc_custom_bpeo_user_can_connect_event_to_group( 20, 0 ) );
+	}
+}

--- a/tests/unit/BpeoGroupEventCapsTest.php
+++ b/tests/unit/BpeoGroupEventCapsTest.php
@@ -86,12 +86,22 @@ class BpeoGroupEventCapsTest extends TestCase {
 		$this->assertSame( array( 'edit_others_events' ), $caps );
 	}
 
-	public function test_group_member_can_connect_event_to_group() {
+	public function test_group_member_can_connect_event_to_group_without_site_role() {
+		// The granted primitive must not depend on the user holding a WP role
+		// (and thus 'read') on the current site: group membership is enough.
 		$GLOBALS['_hc_mock']['group_members'] = array( '11:36' );
 
 		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'connect_event_to_group' ), 'connect_event_to_group', 11, array( 36 ) );
 
-		$this->assertSame( array( 'read' ), $caps );
+		$this->assertSame( array( 'exist' ), $caps );
+	}
+
+	public function test_group_admin_can_connect_event_to_group() {
+		$GLOBALS['_hc_mock']['group_admins'] = array( '17:41' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'connect_event_to_group' ), 'connect_event_to_group', 17, array( 41 ) );
+
+		$this->assertSame( array( 'exist' ), $caps );
 	}
 
 	public function test_non_member_cannot_connect_event_to_group() {
@@ -107,6 +117,43 @@ class BpeoGroupEventCapsTest extends TestCase {
 		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'connect_event_to_group' ), 'connect_event_to_group', 13, array( 38 ) );
 
 		$this->assertSame( array( 'connect_event_to_group' ), $caps );
+	}
+
+	public function test_banned_member_cannot_connect_event_to_group() {
+		$GLOBALS['_hc_mock']['group_members'] = array( '18:42' );
+		$GLOBALS['_hc_mock']['group_banned']  = array( '18:42' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'connect_event_to_group' ), 'connect_event_to_group', 18, array( 42 ) );
+
+		$this->assertSame( array( 'connect_event_to_group' ), $caps );
+	}
+
+	public function test_publish_events_granted_in_group_context_to_member_who_can_connect() {
+		// Publishing from a group's New Event screen must not additionally
+		// require blog-role primitives such as 'read'.
+		$GLOBALS['_hc_mock']['current_group_id'] = 43;
+		$GLOBALS['_hc_mock']['group_members']    = array( '19:43' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'exist', 'read' ), 'publish_events', 19, array() );
+
+		$this->assertSame( array( 'exist' ), $caps );
+	}
+
+	public function test_publish_events_unchanged_outside_group_context() {
+		$GLOBALS['_hc_mock']['group_members'] = array( '19:43' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'exist', 'read' ), 'publish_events', 19, array() );
+
+		$this->assertSame( array( 'exist', 'read' ), $caps );
+	}
+
+	public function test_publish_events_unchanged_in_group_where_user_cannot_connect() {
+		$GLOBALS['_hc_mock']['current_group_id'] = 44;
+		$GLOBALS['_hc_mock']['group_members']    = array( '19:43' );
+
+		$caps = hc_custom_bpeo_group_event_meta_cap( array( 'exist', 'read' ), 'publish_events', 19, array() );
+
+		$this->assertSame( array( 'exist', 'read' ), $caps );
 	}
 
 	public function test_private_event_readable_by_fellow_group_member() {

--- a/tests/unit/BpeoGroupEventsSubnavTest.php
+++ b/tests/unit/BpeoGroupEventsSubnavTest.php
@@ -13,6 +13,7 @@ class BpeoGroupEventsSubnavTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['_hc_mock']              = array();
 		$GLOBALS['_hc_registered_subnav'] = array();
+		$GLOBALS['_mock_group_meta']      = array();
 	}
 
 	/**
@@ -58,9 +59,12 @@ class BpeoGroupEventsSubnavTest extends TestCase {
 		$this->assertSame( array(), $GLOBALS['_hc_registered_subnav'] );
 	}
 
-	public function test_member_who_can_connect_gets_new_event_item() {
+	public function test_group_member_gets_new_event_item_under_member_setting() {
+		// Default setting: any group member may connect events. The New Event
+		// button must appear based on that setting, not on WP blog caps.
 		$this->setUpCurrentGroup();
-		$GLOBALS['_hc_mock']['user_can'] = array( 'connect_event_to_group' => true );
+		$GLOBALS['_hc_mock']['current_user_id'] = 5;
+		$GLOBALS['_hc_mock']['group_members']   = array( '5:50' );
 
 		hc_custom_bpeo_register_group_events_subnav();
 
@@ -70,9 +74,11 @@ class BpeoGroupEventsSubnavTest extends TestCase {
 		$this->assertContains( 'new', $slugs );
 	}
 
-	public function test_member_who_cannot_connect_does_not_get_new_event_item() {
+	public function test_group_member_does_not_get_new_event_item_under_admin_mod_setting() {
 		$this->setUpCurrentGroup();
-		$GLOBALS['_hc_mock']['user_can'] = array( 'connect_event_to_group' => false );
+		$GLOBALS['_hc_mock']['current_user_id'] = 5;
+		$GLOBALS['_hc_mock']['group_members']   = array( '5:50' );
+		$GLOBALS['_hc_mock']['group_min_role']  = array( 50 => 'admin_mod' );
 
 		hc_custom_bpeo_register_group_events_subnav();
 
@@ -82,9 +88,65 @@ class BpeoGroupEventsSubnavTest extends TestCase {
 		$this->assertNotContains( 'new', $slugs );
 	}
 
+	public function test_group_admin_gets_new_event_item_under_admin_mod_setting() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['current_user_id'] = 5;
+		$GLOBALS['_hc_mock']['group_admins']    = array( '5:50' );
+		$GLOBALS['_hc_mock']['group_min_role']  = array( 50 => 'admin_mod' );
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertContains( 'new', $this->registeredSlugs() );
+	}
+
+	public function test_non_member_does_not_get_new_event_item() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['current_user_id'] = 6;
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertNotContains( 'new', $this->registeredSlugs() );
+	}
+
+	public function test_hidden_events_nav_suppresses_subnav_for_regular_member() {
+		// Group admins can hide nav items per group (groupmeta slug => 'hide');
+		// the events subnav must respect that setting for regular members.
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['current_user_id']    = 5;
+		$GLOBALS['_hc_mock']['group_members']      = array( '5:50' );
+		$GLOBALS['_mock_group_meta'][50]['events'] = 'hide';
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertSame( array(), $GLOBALS['_hc_registered_subnav'] );
+	}
+
+	public function test_hidden_events_nav_still_registers_for_group_admin() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['current_user_id']    = 5;
+		$GLOBALS['_hc_mock']['group_admins']       = array( '5:50' );
+		$GLOBALS['_mock_group_meta'][50]['events'] = 'hide';
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertNotEmpty( $GLOBALS['_hc_registered_subnav'] );
+	}
+
+	public function test_hidden_events_nav_still_registers_for_super_admin() {
+		$this->setUpCurrentGroup();
+		$GLOBALS['_hc_mock']['current_user_id']    = 7;
+		$GLOBALS['_hc_mock']['is_super_admin']     = true;
+		$GLOBALS['_mock_group_meta'][50]['events'] = 'hide';
+
+		hc_custom_bpeo_register_group_events_subnav();
+
+		$this->assertNotEmpty( $GLOBALS['_hc_registered_subnav'] );
+	}
+
 	public function test_subnav_items_registered_for_groups_component_under_events_parent() {
 		$this->setUpCurrentGroup();
-		$GLOBALS['_hc_mock']['user_can'] = array( 'connect_event_to_group' => true );
+		$GLOBALS['_hc_mock']['current_user_id'] = 5;
+		$GLOBALS['_hc_mock']['group_members']   = array( '5:50' );
 
 		hc_custom_bpeo_register_group_events_subnav();
 

--- a/tests/unit/group-permissions-loader.php
+++ b/tests/unit/group-permissions-loader.php
@@ -278,6 +278,18 @@ if ( ! function_exists( 'mla_is_group_committee' ) ) {
 	}
 }
 
+if ( ! class_exists( 'Humanities_Commons' ) ) {
+	/**
+	 * Stub of the Humanities Commons plugin class: only the new-member
+	 * vetting check is needed by the code under test.
+	 */
+	class Humanities_Commons {
+		public static function hcommons_vet_user() {
+			return false !== _hc_mock( 'vetted_user', true );
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // BP Event Organiser stubs.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #112 for the reopened #105.

## What was still broken

After the subnav re-registration from #112, the group events subnav came back, but the New Event button was still gated on `current_user_can( 'connect_event_to_group' )`. That capability maps to the `read` primitive, and on our multisite users often hold no WP role on the society site they are visiting (accounts are only given `subscriber` on the site where they are created), so the check failed for everyone — group admins included — no matter what the group's "who may connect events" setting said. That is exactly what the tester's screenshots show: the events settings page says any member may connect events, but the button is missing even for the group admin.

The Manage button, for what it's worth, is landing where it always has: the Events tab of the group admin area (connection setting + iCalendar settings). The group-extension edit screen registers at `bp_actions:8`, where group context is available on BP 14.5, so that part is working; it just looked broken next to the missing button.

## The fix

- New helper `hc_custom_bpeo_user_can_connect_event_to_group()` that decides the permission from the group's `bpeo_connect_member_role` groupmeta ('member' by default, or 'admin_mod') and the user's role in the group: banned users are denied, super admins allowed, and the Humanities Commons new-member vetting is preserved.
- The New Event subnav item, the `connect_event_to_group` mapping, and the group-context `publish_events` mapping all use the helper, granting `exist` rather than `read` so no blog role is needed. The meta-cap filter now runs at priority 30 so bp-event-organiser's own `read`-based mapping can't override it. Changing the setting to "admins and moderators only" hides the button from plain members again.
- The events subnav registration now also honours the per-group "show or hide menu items" setting for the Events tab, matching `hc_custom_remove_group_manager_subnav_tabs()` (admins and site admins always see it).

## Tests

Unit coverage for the helper (setting/roles/banned/vetting), the capability mappings, and the subnav registration (including the hide setting). Full suite: 117 tests, 178 assertions, all passing.