### PR TITLE
fix(hc-custom): stop create-doc saves demanding a per-doc edit nonce

### DIFF
--- a/plugins/hc-custom/includes/buddypress-docs.php
+++ b/plugins/hc-custom/includes/buddypress-docs.php
@@ -479,6 +479,45 @@ function hcommons_correct_bp_get_current_group_id( $current_group_id, $current_g
 }
 add_filter( 'bp_get_current_group_id', 'hcommons_correct_bp_get_current_group_id', 10, 2 );
 
+/**
+ * Resolve to no current doc when a brand-new doc is being saved.
+ *
+ * This addresses @link
+ * https://github.com/MESH-Research/knowledge-commons-wordpress/issues/118
+ *
+ * On /docs/create the main query is the bp_doc post-type archive, so the
+ * global $post holds the first doc of the archive listing. Since
+ * buddypress-docs 2.2.5, BP_Docs_Component::catch_page_load() treats
+ * whatever bp_docs_get_current_doc() returns at save time as the doc being
+ * edited and demands the matching 'bp_docs_edit_{ID}' nonce — which the
+ * create form never contained, because at render time BuddyPress theme
+ * compatibility has already reset the globals to a dummy post with ID 0. The
+ * result is that every create save dies in wp_nonce_ays() with "The link you
+ * followed has expired."
+ *
+ * A create save (no posted doc ID) has no current doc by definition, so
+ * return null and let the archive's first post stop masquerading as one.
+ * Renders and genuine edit saves are left untouched.
+ *
+ * @param WP_Post|null $current_doc The doc detected by bp_docs_get_current_doc().
+ * @return WP_Post|null Null on a create save, the detected doc otherwise.
+ */
+function hc_custom_bp_docs_create_save_current_doc( $current_doc ) {
+	// Only act on doc save requests.
+	if ( empty( $_POST['doc-edit-submit'] ) && empty( $_POST['doc-edit-submit-continue'] ) ) {
+		return $current_doc;
+	}
+
+	// A posted doc ID means this is an edit save; leave it alone.
+	if ( ! empty( $_POST['doc_id'] ) || ! empty( $_POST['doc-id'] ) ) {
+		return $current_doc;
+	}
+
+	// A create save has no current doc.
+	return null;
+}
+add_filter( 'bp_docs_get_current_doc', 'hc_custom_bp_docs_create_save_current_doc', 20, 1 );
+
 function hcommons_restricted_comment_terms_doc_fallback( $terms, $term_query ) {
 	if (
 		isset( $term_query->query_vars['taxonomy'] ) && 

--- a/tests/unit/DocsCreateSaveTest.php
+++ b/tests/unit/DocsCreateSaveTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/docs-create-save-loader.php';
+
+/**
+ * Saving a brand-new doc from /docs/create must not be treated as an edit of
+ * some unrelated existing doc.
+ *
+ * On the create screen the main query is the bp_doc post-type archive, so at
+ * save time buddypress-docs' bp_docs_get_current_doc() falls through to the
+ * global $post — the first doc of the archive listing — and then demands a
+ * per-doc edit nonce that the create form never contained, killing the save
+ * with "The link you followed has expired." The hc-custom filters on
+ * 'bp_docs_get_current_doc' must therefore resolve to no current doc for a
+ * create save, while leaving renders and genuine edit saves untouched.
+ *
+ * These tests exercise the full filter chain hc-custom registers on
+ * 'bp_docs_get_current_doc', exactly as bp_docs_get_current_doc() applies it.
+ */
+class DocsCreateSaveTest extends TestCase {
+
+	/**
+	 * Stand-in for the accidental "current doc": the first doc of the
+	 * archive query that ends up in the global $post at save time.
+	 *
+	 * @var object
+	 */
+	private $accidental_doc;
+
+	protected function setUp(): void {
+		hc_test_reset_state();
+		$_POST = array();
+
+		$this->accidental_doc = (object) array(
+			'ID'        => 42,
+			'post_type' => 'bp_doc',
+		);
+	}
+
+	protected function tearDown(): void {
+		$_POST = array();
+
+		// hc_test_reset_state() sets _mock_current_group_id, which shadows
+		// the _hc_mock store other suites drive bp_get_current_group_id()
+		// with; drop it (and this suite's stores) so no state leaks.
+		unset( $GLOBALS['_mock_current_group_id'] );
+		$GLOBALS['_hc_mock'] = array();
+		$GLOBALS['hc_test']  = array();
+	}
+
+	/**
+	 * Run a doc through the hc-custom 'bp_docs_get_current_doc' filter
+	 * chain, as bp_docs_get_current_doc() would.
+	 *
+	 * @param object|null $doc Doc detected by buddypress-docs.
+	 * @return object|null The doc after filtering.
+	 */
+	private function currentDocAfterFilters( $doc ) {
+		return _test_apply_captured_filters( 'bp_docs_get_current_doc', $doc );
+	}
+
+	/**
+	 * A "Save" POST for a new doc (the create form posts doc_id="0") must
+	 * resolve to no current doc, even though the archive query has left an
+	 * unrelated doc in the globals.
+	 */
+	public function testCreateSaveResolvesToNoCurrentDoc(): void {
+		$_POST['doc-edit-submit'] = 'Save';
+		$_POST['doc_id']          = '0';
+
+		$this->assertNull( $this->currentDocAfterFilters( $this->accidental_doc ) );
+	}
+
+	/**
+	 * The same holds for "Save and Continue Editing", including when the
+	 * doc_id field is missing entirely.
+	 */
+	public function testCreateSaveAndContinueResolvesToNoCurrentDoc(): void {
+		$_POST['doc-edit-submit-continue'] = 'Save and Continue Editing';
+
+		$this->assertNull( $this->currentDocAfterFilters( $this->accidental_doc ) );
+	}
+
+	/**
+	 * A create save that already resolved to no current doc stays that way.
+	 */
+	public function testCreateSaveWithNoDetectedDocStaysEmpty(): void {
+		$_POST['doc-edit-submit'] = 'Save';
+		$_POST['doc_id']          = '';
+
+		$this->assertNull( $this->currentDocAfterFilters( null ) );
+	}
+
+	/**
+	 * Ordinary page renders (no save POST) must keep whatever doc
+	 * buddypress-docs detected — single doc views depend on it.
+	 */
+	public function testRenderRequestKeepsDetectedDoc(): void {
+		$this->assertSame(
+			$this->accidental_doc,
+			$this->currentDocAfterFilters( $this->accidental_doc )
+		);
+	}
+
+	/**
+	 * A genuine edit save (non-empty doc_id) must resolve to the posted
+	 * doc, not the accidental one from the globals.
+	 */
+	public function testEditSaveResolvesToThePostedDoc(): void {
+		$edited_doc = (object) array(
+			'ID'        => 123,
+			'post_type' => 'bp_doc',
+		);
+
+		$GLOBALS['_hc_mock']['posts']           = array( 123 => $edited_doc );
+		$GLOBALS['hc_test']['doc_groups'][123]  = 7;
+
+		$_POST['doc-edit-submit'] = 'Save';
+		$_POST['doc_id']          = '123';
+
+		$this->assertSame(
+			$edited_doc,
+			$this->currentDocAfterFilters( $this->accidental_doc )
+		);
+	}
+
+	/**
+	 * An edit save of a doc with no associated group still resolves to no
+	 * current doc (pre-existing hc-custom behaviour, must be preserved).
+	 */
+	public function testEditSaveOfGroupUnassociatedDocResolvesToNoCurrentDoc(): void {
+		$edited_doc = (object) array(
+			'ID'        => 123,
+			'post_type' => 'bp_doc',
+		);
+
+		$GLOBALS['_hc_mock']['posts']           = array( 123 => $edited_doc );
+		$GLOBALS['hc_test']['doc_groups'][123]  = 0;
+
+		$_POST['doc-edit-submit'] = 'Save';
+		$_POST['doc_id']          = '123';
+
+		$this->assertNull( $this->currentDocAfterFilters( $this->accidental_doc ) );
+	}
+}

--- a/tests/unit/docs-create-save-loader.php
+++ b/tests/unit/docs-create-save-loader.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Loader for the docs create-save current-doc unit tests.
+ *
+ * The code under test lives in plugins/hc-custom/includes/buddypress-docs.php,
+ * which is already loaded (with its WordPress/BuddyPress stubs) by the
+ * group-permissions and group-nav loaders. This loader only adds the stubs
+ * that the create-save tests additionally need.
+ */
+
+require_once __DIR__ . '/group-permissions-loader.php';
+require_once __DIR__ . '/group-nav-loader.php';
+
+if ( ! function_exists( 'bp_docs_get_post_type_name' ) ) {
+	function bp_docs_get_post_type_name() {
+		return 'bp_doc';
+	}
+}
+
+if ( ! function_exists( '_test_apply_captured_filters' ) ) {
+	/**
+	 * Apply every callback captured for a hook, mimicking apply_filters().
+	 */
+	function _test_apply_captured_filters( $hook, $value ) {
+		foreach ( $GLOBALS['_captured_filters'][ $hook ] ?? [] as $callback ) {
+			$value = call_user_func( $callback, $value );
+		}
+		return $value;
+	}
+}


### PR DESCRIPTION
Fixes #118.

Every save from /docs/create (plain "Save" or "Save and Continue Editing") died in `wp_nonce_ays()` with "The link you followed has expired."

## Root cause

The buddypress-docs 2.2.3 → 2.2.7 upgrade (056427d5, merged to dev in the BuddyPress 14 upgrade, 48cd0c87) added a second nonce check to `BP_Docs_Component::catch_page_load()`: whenever `bp_docs_get_current_doc()` reports a doc at save time, the POST must carry a matching `bp_docs_edit_{ID}` nonce (`includes/component.php:479`).

On /docs/create the main query is the `bp_doc` post-type *archive*, so at `bp_actions` the global `$post` is the first doc of the archive listing. `bp_docs_get_current_doc()` skips `get_queried_object()` (a `WP_Post_Type` on archives), falls through to `get_the_ID()`, and wrongly reports that unrelated doc as the doc being saved — so the save is required to carry an edit nonce for a doc the user never touched.

The create form never contains that nonce: by the time the form renders, BuddyPress theme compat has reset the globals to a dummy post with ID 0 (`bp_docs_theme_compat_reset_post( 'create' )`), so `bp_docs_edit_doc_nonce()` bails. Result: `check_admin_referer( 'bp_docs_edit_…' )` fails on every create. The `?group=` argument is incidental. bp-docs 2.2.3 only checked the `bp_docs_save` nonce, which is why this worked before the upgrade.

## Fix

buddypress-docs is third-party, so the fix lives in hc-custom: a filter on `bp_docs_get_current_doc` that resolves to *no current doc* when a doc-save POST carries no doc ID — a create save has no current doc by definition. `catch_page_load()` then only enforces the `bp_docs_save` nonce that the create form actually contains, and `bp_docs_save_doc_via_post()` creates the doc as before (still gated on `current_user_can( 'bp_docs_create' )`).

Edit saves (posted `doc_id`) and ordinary renders pass through untouched, so the 2.2.5 per-doc edit-nonce protection remains fully in force for edits.

## Tests

New `DocsCreateSaveTest` exercises the full hc-custom filter chain on `bp_docs_get_current_doc` for create saves, save-and-continue, renders, and genuine edit saves (including the pre-existing group-association behaviour). Full unit suite: 120 tests, 195 assertions, all passing.