### PR TITLE
fix(hc-custom): stop group doc creation demanding the attachments placeholder's edit nonce

### DIFF
--- a/plugins/hc-custom/includes/buddypress-docs.php
+++ b/plugins/hc-custom/includes/buddypress-docs.php
@@ -485,19 +485,29 @@ add_filter( 'bp_get_current_group_id', 'hcommons_correct_bp_get_current_group_id
  * This addresses @link
  * https://github.com/MESH-Research/knowledge-commons-wordpress/issues/118
  *
- * On /docs/create the main query is the bp_doc post-type archive, so the
- * global $post holds the first doc of the archive listing. Since
- * buddypress-docs 2.2.5, BP_Docs_Component::catch_page_load() treats
+ * Since buddypress-docs 2.2.5, BP_Docs_Component::catch_page_load() treats
  * whatever bp_docs_get_current_doc() returns at save time as the doc being
  * edited and demands the matching 'bp_docs_edit_{ID}' nonce — which the
- * create form never contained, because at render time BuddyPress theme
- * compatibility has already reset the globals to a dummy post with ID 0. The
- * result is that every create save dies in wp_nonce_ays() with "The link you
- * followed has expired."
+ * create form never contained, so the save dies in wp_nonce_ays() with "The
+ * link you followed has expired."
  *
- * A create save (no posted doc ID) has no current doc by definition, so
- * return null and let the archive's first post stop masquerading as one.
- * Renders and genuine edit saves are left untouched.
+ * A create save can be recognised in two ways:
+ *
+ * 1. No posted doc ID at all (the create form renders its hidden doc_id
+ *    field as "0").
+ * 2. A posted doc ID that refers to an 'auto-draft' placeholder. On the
+ *    create screen, the attachments script calls the bp_docs_create_dummy_doc
+ *    AJAX endpoint, which inserts an auto-draft bp_doc (associated with the
+ *    target group when creating from /docs/create/?group=...) and rewrites
+ *    the form's doc_id field with the placeholder's ID so uploads have a
+ *    parent. That placeholder is still a doc *being created* — upstream
+ *    itself treats an auto-draft doc_id as a new doc in
+ *    BP_Docs_Query::save() — so it must not masquerade as the doc being
+ *    edited, or the save handler will demand a per-doc edit nonce that no
+ *    create form ever contains.
+ *
+ * Renders and genuine edit saves (posted doc ID of a real, non-auto-draft
+ * doc) are left untouched, keeping the per-doc nonce protection for edits.
  *
  * @param WP_Post|null $current_doc The doc detected by bp_docs_get_current_doc().
  * @return WP_Post|null Null on a create save, the detected doc otherwise.
@@ -508,13 +518,26 @@ function hc_custom_bp_docs_create_save_current_doc( $current_doc ) {
 		return $current_doc;
 	}
 
-	// A posted doc ID means this is an edit save; leave it alone.
-	if ( ! empty( $_POST['doc_id'] ) || ! empty( $_POST['doc-id'] ) ) {
-		return $current_doc;
+	$posted_doc_id = 0;
+	if ( ! empty( $_POST['doc_id'] ) ) {
+		$posted_doc_id = intval( $_POST['doc_id'] );
+	} elseif ( ! empty( $_POST['doc-id'] ) ) {
+		$posted_doc_id = intval( $_POST['doc-id'] );
 	}
 
-	// A create save has no current doc.
-	return null;
+	// No posted doc ID: a create save has no current doc.
+	if ( ! $posted_doc_id ) {
+		return null;
+	}
+
+	// A posted doc ID that is still an auto-draft is the attachments
+	// placeholder for a doc being created, not a doc being edited.
+	if ( 'auto-draft' === get_post_status( $posted_doc_id ) ) {
+		return null;
+	}
+
+	// A genuine edit save; leave it alone.
+	return $current_doc;
 }
 add_filter( 'bp_docs_get_current_doc', 'hc_custom_bp_docs_create_save_current_doc', 20, 1 );
 

--- a/tests/e2e/tests/docs.spec.ts
+++ b/tests/e2e/tests/docs.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "../fixtures/auth.fixture";
+
+/**
+ * Regression tests for saving a brand-new doc from /docs/create.
+ *
+ * https://github.com/MESH-Research/knowledge-commons-wordpress/issues/118 —
+ * saving the create form died in wp_nonce_ays() with "The link you followed
+ * has expired."
+ */
+
+/** Fill the docs create form and submit it, returning the resulting body text. */
+async function createDoc(page: any, title: string): Promise<string> {
+  await page.locator("#doc-title").fill(title);
+
+  // The content editor is TinyMCE (classic). Write into the underlying
+  // textarea and remove the visual editor so the value survives submission.
+  await page.evaluate(() => {
+    const w = window as any;
+    if (w.tinymce && w.tinymce.get("doc_content")) {
+      w.tinymce.get("doc_content").setContent("Automated test content.");
+    } else {
+      const ta = document.querySelector(
+        "#doc_content"
+      ) as HTMLTextAreaElement | null;
+      if (ta) {
+        ta.value = "Automated test content.";
+      }
+    }
+  });
+
+  await page.locator("#doc-edit-submit").click();
+  await page.waitForLoadState("networkidle");
+
+  return page.locator("body").innerText();
+}
+
+test.describe.serial("Docs", () => {
+  const groupName = `Docs E2E Group ${Date.now()}`;
+  const groupSlug = groupName.toLowerCase().replace(/\s+/g, "-");
+
+  test("create a group to hold docs", async ({
+    authenticatedPage: page,
+    capture,
+  }) => {
+    await page.goto("/groups/create/step/group-details/");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator("#group-name").fill(groupName);
+    await page
+      .locator("#group-desc")
+      .fill("Automated group for docs create tests.");
+    await page.waitForTimeout(500);
+
+    await page.locator("#group-creation-create").click();
+    await page.waitForLoadState("networkidle");
+
+    // Walk through the remaining wizard steps.
+    for (let i = 0; i < 7; i++) {
+      const finish = page.locator("#group-creation-finish");
+      const next = page.locator("#group-creation-next");
+      if (await finish.isVisible({ timeout: 500 }).catch(() => false)) {
+        await finish.click();
+        break;
+      } else if (await next.isVisible({ timeout: 500 }).catch(() => false)) {
+        await next.click();
+        await page.waitForLoadState("networkidle");
+      } else {
+        break;
+      }
+    }
+
+    await page.waitForLoadState("networkidle");
+    await capture("01-docs-group-created");
+
+    await page.goto(`/groups/${groupSlug}/`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("body")).toContainText(groupName);
+  });
+
+  test("save a new doc from /docs/create without a group", async ({
+    authenticatedPage: page,
+    capture,
+  }) => {
+    const docTitle = `E2E Doc No Group ${Date.now()}`;
+
+    await page.goto("/docs/create/");
+    await page.waitForLoadState("networkidle");
+    await capture("02-docs-create-form");
+
+    const bodyText = await createDoc(page, docTitle);
+    await capture("03-docs-create-saved");
+
+    expect(bodyText).not.toContain("The link you followed has expired");
+    await expect(page.locator("body")).toContainText(docTitle);
+  });
+
+  test("save a new doc from /docs/create?group=... in a group", async ({
+    authenticatedPage: page,
+    capture,
+  }) => {
+    test.skip(!groupSlug, "Group was not created");
+
+    const docTitle = `E2E Doc In Group ${Date.now()}`;
+
+    await page.goto(`/docs/create/?group=${groupSlug}`);
+    await page.waitForLoadState("networkidle");
+    await capture("04-docs-create-group-form");
+
+    const bodyText = await createDoc(page, docTitle);
+    await capture("05-docs-create-group-saved");
+
+    expect(bodyText).not.toContain("The link you followed has expired");
+    await expect(page.locator("body")).toContainText(docTitle);
+  });
+});

--- a/tests/unit/DocsCreateSaveTest.php
+++ b/tests/unit/DocsCreateSaveTest.php
@@ -127,6 +127,73 @@ class DocsCreateSaveTest extends TestCase {
 	}
 
 	/**
+	 * A create save in a group must resolve to no current doc even though the
+	 * attachments JS has replaced the form's doc_id with the ID of the
+	 * auto-draft placeholder it created (and associated with the group) via
+	 * the bp_docs_create_dummy_doc AJAX endpoint. Treating the placeholder as
+	 * the doc being edited makes the save handler demand a per-doc edit nonce
+	 * the create form never contained.
+	 */
+	public function testGroupCreateSaveWithAutoDraftPlaceholderResolvesToNoCurrentDoc(): void {
+		$placeholder = (object) array(
+			'ID'        => 21,
+			'post_type' => 'bp_doc',
+		);
+
+		$GLOBALS['_hc_mock']['posts']         = array( 21 => $placeholder );
+		$GLOBALS['_hc_mock']['post_statuses'] = array( 21 => 'auto-draft' );
+		$GLOBALS['hc_test']['doc_groups'][21] = 7;
+
+		$_POST['doc-edit-submit'] = 'Save';
+		$_POST['doc_id']          = '21';
+
+		$this->assertNull( $this->currentDocAfterFilters( $this->accidental_doc ) );
+	}
+
+	/**
+	 * The same holds for a create save outside any group: the auto-draft
+	 * placeholder ID posted as doc_id must not surface as a current doc.
+	 */
+	public function testNoGroupCreateSaveWithAutoDraftPlaceholderResolvesToNoCurrentDoc(): void {
+		$placeholder = (object) array(
+			'ID'        => 18,
+			'post_type' => 'bp_doc',
+		);
+
+		$GLOBALS['_hc_mock']['posts']         = array( 18 => $placeholder );
+		$GLOBALS['_hc_mock']['post_statuses'] = array( 18 => 'auto-draft' );
+		$GLOBALS['hc_test']['doc_groups'][18] = 0;
+
+		$_POST['doc-edit-submit'] = 'Save';
+		$_POST['doc_id']          = '18';
+
+		$this->assertNull( $this->currentDocAfterFilters( $this->accidental_doc ) );
+	}
+
+	/**
+	 * A genuine edit save of a published doc keeps resolving to the posted
+	 * doc — the per-doc nonce protection must stay intact for real edits.
+	 */
+	public function testEditSaveOfPublishedDocKeepsResolvingToThePostedDoc(): void {
+		$edited_doc = (object) array(
+			'ID'        => 123,
+			'post_type' => 'bp_doc',
+		);
+
+		$GLOBALS['_hc_mock']['posts']          = array( 123 => $edited_doc );
+		$GLOBALS['_hc_mock']['post_statuses']  = array( 123 => 'publish' );
+		$GLOBALS['hc_test']['doc_groups'][123] = 7;
+
+		$_POST['doc-edit-submit'] = 'Save';
+		$_POST['doc_id']          = '123';
+
+		$this->assertSame(
+			$edited_doc,
+			$this->currentDocAfterFilters( $this->accidental_doc )
+		);
+	}
+
+	/**
 	 * An edit save of a doc with no associated group still resolves to no
 	 * current doc (pre-existing hc-custom behaviour, must be preserved).
 	 */

--- a/tests/unit/docs-create-save-loader.php
+++ b/tests/unit/docs-create-save-loader.php
@@ -17,6 +17,16 @@ if ( ! function_exists( 'bp_docs_get_post_type_name' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_post_status' ) ) {
+	/**
+	 * Status of a mocked post, driven by $GLOBALS['_hc_mock']['post_statuses'].
+	 */
+	function get_post_status( $post = null ) {
+		$post_id = is_object( $post ) ? ( $post->ID ?? 0 ) : (int) $post;
+		return $GLOBALS['_hc_mock']['post_statuses'][ $post_id ] ?? false;
+	}
+}
+
 if ( ! function_exists( '_test_apply_captured_filters' ) ) {
 	/**
 	 * Apply every callback captured for a hook, mimicking apply_filters().


### PR DESCRIPTION
Fixes #118 — for real this time. The earlier fix (#119) addressed a genuine problem but not the one that kills group doc creation.

## What actually fails

Reproduced end-to-end: saving from `/docs/create/` succeeds, saving from `/docs/create/?group=...` dies in `wp_nonce_ays()`. Instrumenting every `check_admin_referer()` call shows the legacy `bp_docs_save` check **passes**; the check that dies is `bp_docs_edit_{ID}` at `component.php:479` — for a doc ID that didn't exist when the form rendered.

The missing piece is buddypress-docs' attachments bootstrap. On the create screen, `attachments.js` calls the `bp_docs_create_dummy_doc` AJAX endpoint, which inserts an **auto-draft** placeholder doc and rewrites the form's hidden `doc_id` field with its ID (`$('input#doc_id').val(response.doc_id)`) so uploads have a parent. When `?group=` is present, the endpoint also associates the placeholder with the group.

So at save time `doc_id` is never the empty `0` that #119 keyed on — it's the placeholder's ID. hc-custom's pre-existing current-doc correction (`hcommons_correct_bp_docs_get_current_doc`) then resolves that group-associated placeholder as "the doc being edited", and `catch_page_load()` demands a `bp_docs_edit_{ID}` nonce that no create form ever contains. Creates outside a group only survived because the unassociated placeholder falls into that filter's return-null branch — which is why #119's e2e-visible symptom seemed fixed.

## The fix

In `hc_custom_bp_docs_create_save_current_doc`, treat a posted `doc_id` that is still an `auto-draft` as a create save and resolve to no current doc — mirroring upstream's own is-new-doc test in `BP_Docs_Query::save()` (`query-builder.php:509`). Genuine edit saves (real, non-auto-draft docs) keep the full per-doc nonce protection, and creation remains gated on `bp_docs_create` / group-association capability checks inside `bp_docs_save_doc_via_post()`.

## Testing

- Unit: three new behaviour-level cases in `DocsCreateSaveTest` (group-associated placeholder → no current doc; unassociated placeholder → no current doc; published doc edit → still resolves to the posted doc). Suite: 123 tests / 198 assertions, all passing.
- E2E: new `tests/e2e/tests/docs.spec.ts` creates a group and saves a new doc both with and without `?group=`. Fails on current dev (group case dies with "The link you followed has expired"), passes with this change; full Playwright suite 11/11 green.