### PR TITLE
test(e2e): assert the group docs tab links back to its group

### DIFF
--- a/tests/e2e/tests/docs.spec.ts
+++ b/tests/e2e/tests/docs.spec.ts
@@ -112,4 +112,30 @@ test.describe.serial("Docs", () => {
     expect(bodyText).not.toContain("The link you followed has expired");
     await expect(page.locator("body")).toContainText(docTitle);
   });
+
+  test("group docs tab links back to the group", async ({
+    authenticatedPage: page,
+    capture,
+  }) => {
+    test.skip(!groupSlug, "Group was not created");
+
+    // https://github.com/MESH-Research/knowledge-commons-wordpress/issues/121
+    // The group docs tab must render inside the group's own page, so there
+    // is always a way back to the group (header title / group nav). A theme
+    // that swaps in a standalone docs template here strands the visitor.
+    await page.goto(`/groups/${groupSlug}/docs/`);
+    await page.waitForLoadState("networkidle");
+    await capture("06-group-docs-back-link");
+
+    // The docs list itself rendered...
+    await expect(page.locator("#buddypress")).toBeAttached();
+
+    // ...and at least one link leads back to the group's home page. The
+    // group's own docs tab URL (/groups/slug/docs/) must not satisfy this.
+    const backLink = page.locator(`a[href$="/groups/${groupSlug}/"]`).first();
+    await expect(backLink).toBeAttached();
+
+    // The group's name is shown as page context, not just as a tab label.
+    await expect(page.locator("body")).toContainText(groupName);
+  });
 });


### PR DESCRIPTION
Companion to MESH-Research/hcommons-mpe-theme#23, which fixes #121.

The root cause of #121 lives in hcommons-mpe-theme: its `template_include` filter swapped in a standalone docs template whenever `bp_docs_is_docs_component()` was true, which includes a group's docs tab, stripping the group header/nav and leaving no way back to the group. The theme PR makes it bail in group context so BuddyPress renders the docs tab inside the group page as usual.

This PR adds the e2e regression guard on this side: the Playwright docs suite now asserts that `/groups/{slug}/docs/` contains a link back to the group's home URL (the group's own docs-tab URL cannot satisfy the locator) and shows the group name as page context. On a run with the mpe theme installed and active, this test fails against the unfixed theme and passes with the fix; on the stock harness theme it documents the expected BuddyPress behaviour.

Unit suite: 123 tests, 198 assertions, green.

Fixes #121